### PR TITLE
feat: multi-idioma (ES/EN/IT/PT) + comandos de voz y permiso unico

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,82 +1,86 @@
 # 🧪 Molecule Lab
 
-**Combiná átomos con tus manos y tu voz.** Un laboratorio de química en el navegador:
-nombrás un átomo y aparece en tu mano, lo tirás a un **cuenco de alquimia** en el centro
-de la escena y, al mezclar, se forma una molécula real. Todo lo que creás queda en un
-**inventario** para volver a usarlo — y las moléculas creadas se pueden combinar entre sí
-para descubrir compuestos más complejos. Seguimiento de manos sobre tu webcam, sin
-controles ni instalaciones.
+**Combine atoms with your hands and your voice.** A chemistry lab in your browser:
+name an atom and it appears in your hand, drop it into an **alchemy cauldron** at the
+center of the scene, and on mixing a real molecule forms. Everything you create is kept
+in an **inventory** to reuse — and the molecules you make can be combined with each other
+to discover more complex compounds. Hand-tracking over your webcam, no controllers, no
+installs.
 
-🔗 **[Jugar online →](https://damiansire.github.io/web-ar-molecule-lab/)**
+🔗 **[Play online →](https://damiansire.github.io/web-ar-molecule-lab/)**
 
-![Cuenco de Alquimia](docs/preview.png)
+![Molecule Lab](docs/preview.png)
 
-## Cómo se juega
+## How to play
 
-1. Tocá **Activar cámara** y permití el acceso.
-2. **Decí el nombre de un átomo** (“hidrógeno”, “oxígeno”…) y aparece en tu mano. Si no
-   tenés micrófono, podés agarrarlo de la **paleta** de arriba dejando el dedo encima.
-3. **Acercá la mano al cuenco** para soltar adentro lo que sostenés. Repetí para acumular
-   (ej. 2 hidrógeno + 1 oxígeno).
-4. Decí **“mezclar”** (o dejá el dedo en el botón **✨ Mezclar**) y el cuenco resuelve la
-   receta: nace la molécula y entra a tu **inventario**. ¿No reacciona? Ajustá y probá de
-   nuevo, o **🗑 Vaciar** para empezar de cero.
-5. Lo que ya creaste lo **re-invocás** por voz (“agua”) o sacándolo del **estante** de
-   inventario con la mano — y lo podés tirar de vuelta al cuenco como ingrediente.
+1. Click **Activar cámara** and allow access.
+2. **Say the name of an atom** (“hidrógeno”, “oxígeno”…) and it appears in your hand. No
+   microphone? Grab it from the **palette** at the top by holding your fingertip over it.
+3. **Bring your hand to the cauldron** to drop in what you are holding. Repeat to stack
+   up (e.g. 2 hydrogen + 1 oxygen).
+4. Say **“mezclar”** (or hold your fingertip on the **✨ Mezclar** button) and the
+   cauldron resolves the recipe: the molecule is born and enters your **inventory**. No
+   reaction? Adjust and try again, or **🗑 Vaciar** to start over.
+5. Anything you already made can be **re-summoned** by voice (“agua”) or by taking it from
+   the inventory **shelf** with your hand — and you can drop it back into the cauldron as
+   an ingredient.
 
-### El árbol de alquimia
+> The voice commands are in Spanish (the recognizer runs in `es-AR`): say the Spanish name
+> of an atom or product, or “mezclar” to brew.
 
-Las moléculas creadas son ingredientes de nuevas recetas. Por ejemplo:
+### The alchemy tree
 
-- **Agua** (2 H + 1 O) + **Dióxido de carbono** (1 C + 2 O) → **Ácido carbónico**
-- **Amoníaco** (1 N + 3 H) + **Ácido clorhídrico** → **Cloruro de amonio**
-- **Dióxido de azufre** + **Agua** → **Ácido sulfuroso**
+The molecules you create are ingredients for new recipes. For example:
 
-Primero craftás los intermedios; después los combinás. El inventario es persistente: tu
-avance sobrevive a recargar la página.
+- **Water** (2 H + 1 O) + **Carbon dioxide** (1 C + 2 O) → **Carbonic acid**
+- **Ammonia** (1 N + 3 H) + **Hydrochloric acid** → **Ammonium chloride**
+- **Sulfur dioxide** + **Water** → **Sulfurous acid**
 
-## Química
+You craft the intermediates first, then combine them. The inventory is persistent: your
+progress survives a page reload.
 
-- **Elementos (9):** H · O · C · N · S · P · F · Na · Cl
-- **Moléculas de 1.er nivel:** H₂O, CO₂, NH₃, CH₄, NaCl, HCl, H₂, O₂, N₂, H₂O₂, O₃, CO,
+## Chemistry
+
+- **Elements (9):** H · O · C · N · S · P · F · Na · Cl
+- **First-level molecules:** H₂O, CO₂, NH₃, CH₄, NaCl, HCl, H₂, O₂, N₂, H₂O₂, O₃, CO,
   NO, SO₂, H₂S, HF, PH₃
-- **Compuestos del árbol de alquimia:** H₂CO₃, NH₄Cl, H₂SO₃, NH₄OH
+- **Alchemy-tree compounds:** H₂CO₃, NH₄Cl, H₂SO₃, NH₄OH
 
-Las combinaciones se resuelven por **identidad de ingrediente**: un átomo o un producto ya
-creado. Agregar contenido es declarativo — sumar un elemento, una molécula (con su
-geometría) o una receta a `src/chemistry.ts`.
+Combinations are resolved by **ingredient identity**: an atom or an already-created
+product. Adding content is declarative — add an element, a molecule (with its geometry),
+or a recipe in `src/chemistry.ts`.
 
-## Privacidad
+## Privacy
 
-Todo corre **en tu dispositivo**. El video de la cámara y el modelo de seguimiento de
-manos se ejecutan localmente en el navegador — la imagen nunca sale de tu máquina. No se
-descarga ni se contacta nada hasta que tocás *Activar cámara*.
+Everything runs **on your device**. The camera stream and the hand-tracking model execute
+locally in your browser — the video never leaves your machine. Nothing is downloaded or
+contacted until you click *Activar cámara*.
 
-## Tecnología
+## Tech
 
-- **Vite + TypeScript**, renderizado en un `<canvas>` 2D sobre la webcam espejada.
-- **Seguimiento de manos** con [MediaPipe Tasks Vision](https://developers.google.com/mediapipe),
-  corriendo en un Web Worker para que la inferencia nunca bloquee el render.
-- **Voz** con la Web Speech API (opcional; el juego funciona completo solo con gestos).
-- **Dominio puro y testeado** (`src/chemistry.ts`): elementos, moléculas, recetas y el
-  resolutor del cuenco (`brew`) viven sin DOM y se cubren con tests unitarios.
-- Una **Content-Security-Policy** estricta inyectada en build acota la red a los CDNs
-  imprescindibles para el modelo.
+- **Vite + TypeScript**, rendered on a 2D `<canvas>` over the mirrored webcam.
+- **Hand tracking** via [MediaPipe Tasks Vision](https://developers.google.com/mediapipe),
+  running in a Web Worker so inference never blocks the render loop.
+- **Voice** via the Web Speech API (optional; the game works fully with gestures alone).
+- **Pure, tested domain** (`src/chemistry.ts`): elements, molecules, recipes and the
+  cauldron resolver (`brew`) live without the DOM and are covered by unit tests.
+- A strict **Content-Security-Policy** injected at build time scopes network access to
+  only the CDNs strictly required by the model.
 
-## Desarrollo
+## Development
 
 ```bash
 npm install
-npm run dev       # dev server en /web-ar-molecule-lab/
-npm test          # tests unitarios (chemistry, inventory, voice, hands)
-npm run build     # build de producción → dist/
+npm run dev       # dev server at /web-ar-molecule-lab/
+npm test          # unit tests (chemistry, inventory, voice, hands)
+npm run build     # production build → dist/
 ```
 
-> Requiere un navegador con soporte de `getUserMedia` (cámara). El micrófono es opcional y
-> solo se usa para nombrar átomos/productos y decir “mezclar”.
+> Requires a browser with `getUserMedia` (camera) support. A microphone is optional and
+> only used to name atoms/products and say “mezclar”.
 
-## Deploy
+## Deployment
 
-Pushear a `master` dispara un workflow de GitHub Actions que buildea el proyecto y publica
-`dist/` en GitHub Pages. El `base` de Vite es `/web-ar-molecule-lab/` para que coincida con
-el subpath de Pages.
+Pushing to `master` triggers a GitHub Actions workflow that builds the project and
+publishes `dist/` to GitHub Pages. The Vite `base` is set to `/web-ar-molecule-lab/` to
+match the Pages subpath.

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="es">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://storage.googleapis.com" crossorigin />
     <link rel="dns-prefetch" href="https://cdn.jsdelivr.net" />
     <link rel="dns-prefetch" href="https://storage.googleapis.com" />
-    <title>Cuenco de Alquimia — combiná átomos con tus manos y tu voz</title>
+    <title>Alchemy Cauldron — combine atoms with your hands and voice</title>
   </head>
   <body>
     <canvas id="stage"></canvas>
@@ -23,10 +23,10 @@
         <div id="langs" class="langs" role="group" aria-label="Language / Idioma"></div>
         <div class="logo">⚗️</div>
         <h1 id="title">Alchemy&nbsp;Cauldron</h1>
-        <p class="lead">Activá la cámara para jugar.</p>
-        <button id="start" type="button">Activar cámara</button>
-        <p class="privacy">🔒 Corre en tu dispositivo · tu cámara nunca sale de acá</p>
-        <p class="hint" id="status">No se carga nada hasta que empieces.</p>
+        <p class="lead">Enable your camera to play.</p>
+        <button id="start" type="button">Enable camera</button>
+        <p class="privacy">🔒 Runs on your device · your camera never leaves it</p>
+        <p class="hint" id="status">Nothing loads until you start.</p>
       </div>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -14,10 +14,15 @@
     <canvas id="stage"></canvas>
     <video id="cam" playsinline muted></video>
 
+    <!-- Selector de idioma siempre visible (también dentro del juego). -->
+    <div id="langbar" class="langbar" role="group" aria-label="Language / Idioma"></div>
+
     <div id="overlay">
       <div class="card">
+        <div class="lang-title">🌐 Language · Idioma</div>
+        <div id="langs" class="langs" role="group" aria-label="Language / Idioma"></div>
         <div class="logo">⚗️</div>
-        <h1>Cuenco&nbsp;de&nbsp;Alquimia</h1>
+        <h1 id="title">Alchemy&nbsp;Cauldron</h1>
         <p class="lead">Activá la cámara para jugar.</p>
         <button id="start" type="button">Activar cámara</button>
         <p class="privacy">🔒 Corre en tu dispositivo · tu cámara nunca sale de acá</p>

--- a/src/chemistry.test.ts
+++ b/src/chemistry.test.ts
@@ -6,6 +6,8 @@ import {
   brew,
   ingredientKey,
   ingredientLabel,
+  localizedName,
+  allNames,
   RECIPES,
   ALCHEMY_RECIPES,
   MOLECULES,
@@ -145,9 +147,19 @@ describe('recetas y productos', () => {
     expect(new Set(keys).size).toBe(keys.length);
   });
 
-  it('ingredientLabel devuelve el nombre en español de átomos y productos', () => {
-    expect(ingredientLabel('O')).toBe('Oxígeno');
-    expect(ingredientLabel('H₂O')).toBe('Agua');
+  it('ingredientLabel devuelve el nombre localizado de átomos y productos', () => {
+    expect(ingredientLabel('O', 'es')).toBe('Oxígeno');
+    expect(ingredientLabel('O', 'en')).toBe('Oxygen');
+    expect(ingredientLabel('O', 'it')).toBe('Ossigeno');
+    expect(ingredientLabel('H₂O', 'pt')).toBe('Água');
+    expect(ingredientLabel('H₂O', 'es')).toBe('Agua');
+  });
+
+  it('localizedName y allNames cubren los 4 idiomas', () => {
+    expect(localizedName(ELEMENTS.Na, 'it')).toBe('Sodio');
+    expect(localizedName(ELEMENTS.S, 'pt')).toBe('Enxofre');
+    const water = MOLECULES.find((m) => m.formula === 'H₂O')!;
+    expect(allNames(water)).toEqual(['Water', 'Agua', 'Acqua', 'Água']);
   });
 });
 
@@ -194,8 +206,13 @@ describe('catálogo', () => {
     }
   });
 
-  it('todo elemento y molécula tiene nombre en español', () => {
-    for (const sym of ELEMENT_ORDER) expect(ELEMENTS[sym].nameEs.trim().length).toBeGreaterThan(1);
-    for (const m of MOLECULES) expect(m.nameEs.trim().length).toBeGreaterThan(1);
+  it('todo elemento y molécula tiene nombre en los 4 idiomas', () => {
+    for (const sym of ELEMENT_ORDER) {
+      const el = ELEMENTS[sym];
+      for (const n of [el.name, el.nameEs, el.nameIt, el.namePt]) expect(n.trim().length).toBeGreaterThan(1);
+    }
+    for (const m of MOLECULES) {
+      for (const n of [m.name, m.nameEs, m.nameIt, m.namePt]) expect(n.trim().length).toBeGreaterThan(1);
+    }
   });
 });

--- a/src/chemistry.ts
+++ b/src/chemistry.ts
@@ -4,13 +4,20 @@
  * Sin dependencias del DOM ni de la cámara: se testea aislado con Vitest.
  */
 
+import type { Lang } from './i18n';
+
 export type ElementSymbol = 'H' | 'O' | 'C' | 'N' | 'Na' | 'Cl' | 'F' | 'S' | 'P';
 
 export interface ChemElement {
   symbol: ElementSymbol;
+  /** Nombre en inglés. */
   name: string;
-  /** Nombre en español, para el HUD y el match de voz. */
+  /** Nombre en español. */
   nameEs: string;
+  /** Nombre en italiano. */
+  nameIt: string;
+  /** Nombre en portugués. */
+  namePt: string;
   /** Número atómico (protones). */
   atomicNumber: number;
   /** Color base para el render (hex). */
@@ -38,9 +45,14 @@ export type Composition = Partial<Record<ElementSymbol, number>>;
 
 export interface Molecule {
   formula: string;
+  /** Nombre en inglés. */
   name: string;
-  /** Nombre en español, para el HUD y el match de voz. */
+  /** Nombre en español. */
   nameEs: string;
+  /** Nombre en italiano. */
+  nameIt: string;
+  /** Nombre en portugués. */
+  namePt: string;
   color: string;
   /** Descripción breve: para qué se usa / por qué importa (en inglés). */
   description: string;
@@ -67,15 +79,15 @@ export interface ElementStack {
 // Catálogo de elementos
 // ---------------------------------------------------------------------------
 export const ELEMENTS: Record<ElementSymbol, ChemElement> = {
-  H: { symbol: 'H', name: 'Hydrogen', nameEs: 'Hidrógeno', atomicNumber: 1, color: '#7dd3fc', category: 'no-metal', radius: 0.3, shells: [1] },
-  O: { symbol: 'O', name: 'Oxygen', nameEs: 'Oxígeno', atomicNumber: 8, color: '#f87171', category: 'no-metal', radius: 0.42, shells: [2, 6] },
-  C: { symbol: 'C', name: 'Carbon', nameEs: 'Carbono', atomicNumber: 6, color: '#94a3b8', category: 'no-metal', radius: 0.45, shells: [2, 4] },
-  N: { symbol: 'N', name: 'Nitrogen', nameEs: 'Nitrógeno', atomicNumber: 7, color: '#818cf8', category: 'no-metal', radius: 0.42, shells: [2, 5] },
-  Na: { symbol: 'Na', name: 'Sodium', nameEs: 'Sodio', atomicNumber: 11, color: '#fbbf24', category: 'metal', radius: 0.55, shells: [2, 8, 1] },
-  Cl: { symbol: 'Cl', name: 'Chlorine', nameEs: 'Cloro', atomicNumber: 17, color: '#4ade80', category: 'halogeno', radius: 0.5, shells: [2, 8, 7] },
-  F: { symbol: 'F', name: 'Fluorine', nameEs: 'Flúor', atomicNumber: 9, color: '#a3e635', category: 'halogeno', radius: 0.38, shells: [2, 7] },
-  S: { symbol: 'S', name: 'Sulfur', nameEs: 'Azufre', atomicNumber: 16, color: '#facc15', category: 'no-metal', radius: 0.5, shells: [2, 8, 6] },
-  P: { symbol: 'P', name: 'Phosphorus', nameEs: 'Fósforo', atomicNumber: 15, color: '#fb923c', category: 'no-metal', radius: 0.5, shells: [2, 8, 5] },
+  H: { symbol: 'H', name: 'Hydrogen', nameEs: 'Hidrógeno', nameIt: 'Idrogeno', namePt: 'Hidrogênio', atomicNumber: 1, color: '#7dd3fc', category: 'no-metal', radius: 0.3, shells: [1] },
+  O: { symbol: 'O', name: 'Oxygen', nameEs: 'Oxígeno', nameIt: 'Ossigeno', namePt: 'Oxigênio', atomicNumber: 8, color: '#f87171', category: 'no-metal', radius: 0.42, shells: [2, 6] },
+  C: { symbol: 'C', name: 'Carbon', nameEs: 'Carbono', nameIt: 'Carbonio', namePt: 'Carbono', atomicNumber: 6, color: '#94a3b8', category: 'no-metal', radius: 0.45, shells: [2, 4] },
+  N: { symbol: 'N', name: 'Nitrogen', nameEs: 'Nitrógeno', nameIt: 'Azoto', namePt: 'Nitrogênio', atomicNumber: 7, color: '#818cf8', category: 'no-metal', radius: 0.42, shells: [2, 5] },
+  Na: { symbol: 'Na', name: 'Sodium', nameEs: 'Sodio', nameIt: 'Sodio', namePt: 'Sódio', atomicNumber: 11, color: '#fbbf24', category: 'metal', radius: 0.55, shells: [2, 8, 1] },
+  Cl: { symbol: 'Cl', name: 'Chlorine', nameEs: 'Cloro', nameIt: 'Cloro', namePt: 'Cloro', atomicNumber: 17, color: '#4ade80', category: 'halogeno', radius: 0.5, shells: [2, 8, 7] },
+  F: { symbol: 'F', name: 'Fluorine', nameEs: 'Flúor', nameIt: 'Fluoro', namePt: 'Flúor', atomicNumber: 9, color: '#a3e635', category: 'halogeno', radius: 0.38, shells: [2, 7] },
+  S: { symbol: 'S', name: 'Sulfur', nameEs: 'Azufre', nameIt: 'Zolfo', namePt: 'Enxofre', atomicNumber: 16, color: '#facc15', category: 'no-metal', radius: 0.5, shells: [2, 8, 6] },
+  P: { symbol: 'P', name: 'Phosphorus', nameEs: 'Fósforo', nameIt: 'Fosforo', namePt: 'Fósforo', atomicNumber: 15, color: '#fb923c', category: 'no-metal', radius: 0.5, shells: [2, 8, 5] },
 };
 
 export const ELEMENT_ORDER: ElementSymbol[] = ['H', 'O', 'C', 'N', 'S', 'P', 'F', 'Na', 'Cl'];
@@ -85,7 +97,7 @@ export const ELEMENT_ORDER: ElementSymbol[] = ['H', 'O', 'C', 'N', 'S', 'P', 'F'
 // ---------------------------------------------------------------------------
 export const MOLECULES: Molecule[] = [
   {
-    formula: 'H₂O', name: 'Water', nameEs: 'Agua', color: '#38bdf8',
+    formula: 'H₂O', name: 'Water', nameEs: 'Agua', nameIt: 'Acqua', namePt: 'Água', color: '#38bdf8',
     description: 'The basis of all known life. Covers about 71% of Earth and makes up most of your body.',
     composition: { H: 2, O: 1 },
     atoms: [
@@ -96,7 +108,7 @@ export const MOLECULES: Molecule[] = [
     bonds: [{ a: 0, b: 1, order: 1 }, { a: 0, b: 2, order: 1 }],
   },
   {
-    formula: 'CO₂', name: 'Carbon dioxide', nameEs: 'Dióxido de carbono', color: '#94a3b8',
+    formula: 'CO₂', name: 'Carbon dioxide', nameEs: 'Dióxido de carbono', nameIt: 'Anidride carbonica', namePt: 'Dióxido de carbono', color: '#94a3b8',
     description: 'Exhaled by animals, used by plants in photosynthesis, and a key greenhouse gas.',
     composition: { C: 1, O: 2 },
     atoms: [
@@ -107,7 +119,7 @@ export const MOLECULES: Molecule[] = [
     bonds: [{ a: 0, b: 1, order: 2 }, { a: 0, b: 2, order: 2 }],
   },
   {
-    formula: 'NH₃', name: 'Ammonia', nameEs: 'Amoníaco', color: '#a5b4fc',
+    formula: 'NH₃', name: 'Ammonia', nameEs: 'Amoníaco', nameIt: 'Ammoniaca', namePt: 'Amônia', color: '#a5b4fc',
     description: 'Used to make fertilizers that feed most of the world, and in cleaning products.',
     composition: { N: 1, H: 3 },
     atoms: [
@@ -119,7 +131,7 @@ export const MOLECULES: Molecule[] = [
     bonds: [{ a: 0, b: 1, order: 1 }, { a: 0, b: 2, order: 1 }, { a: 0, b: 3, order: 1 }],
   },
   {
-    formula: 'CH₄', name: 'Methane', nameEs: 'Metano', color: '#5eead4',
+    formula: 'CH₄', name: 'Methane', nameEs: 'Metano', nameIt: 'Metano', namePt: 'Metano', color: '#5eead4',
     description: 'The main component of natural gas — a common fuel and a potent greenhouse gas.',
     composition: { C: 1, H: 4 },
     atoms: [
@@ -135,7 +147,7 @@ export const MOLECULES: Molecule[] = [
     ],
   },
   {
-    formula: 'NaCl', name: 'Salt (sodium chloride)', nameEs: 'Sal', color: '#fcd34d',
+    formula: 'NaCl', name: 'Salt (sodium chloride)', nameEs: 'Sal', nameIt: 'Sale', namePt: 'Sal', color: '#fcd34d',
     description: 'Everyday table salt. Essential for life and used to season and preserve food.',
     composition: { Na: 1, Cl: 1 },
     atoms: [
@@ -145,7 +157,7 @@ export const MOLECULES: Molecule[] = [
     bonds: [{ a: 0, b: 1, order: 1 }],
   },
   {
-    formula: 'HCl', name: 'Hydrochloric acid', nameEs: 'Ácido clorhídrico', color: '#86efac',
+    formula: 'HCl', name: 'Hydrochloric acid', nameEs: 'Ácido clorhídrico', nameIt: 'Acido cloridrico', namePt: 'Ácido clorídrico', color: '#86efac',
     description: 'Your stomach makes it to digest food. Also a workhorse acid in industry.',
     composition: { H: 1, Cl: 1 },
     atoms: [
@@ -155,7 +167,7 @@ export const MOLECULES: Molecule[] = [
     bonds: [{ a: 0, b: 1, order: 1 }],
   },
   {
-    formula: 'H₂', name: 'Hydrogen gas', nameEs: 'Hidrógeno gaseoso', color: '#7dd3fc',
+    formula: 'H₂', name: 'Hydrogen gas', nameEs: 'Hidrógeno gaseoso', nameIt: 'Idrogeno gassoso', namePt: 'Hidrogênio gasoso', color: '#7dd3fc',
     description: 'The lightest gas and a clean fuel: burning it produces only water.',
     composition: { H: 2 },
     atoms: [
@@ -165,7 +177,7 @@ export const MOLECULES: Molecule[] = [
     bonds: [{ a: 0, b: 1, order: 1 }],
   },
   {
-    formula: 'O₂', name: 'Oxygen gas', nameEs: 'Oxígeno gaseoso', color: '#f87171',
+    formula: 'O₂', name: 'Oxygen gas', nameEs: 'Oxígeno gaseoso', nameIt: 'Ossigeno gassoso', namePt: 'Oxigênio gasoso', color: '#f87171',
     description: 'The gas you breathe to stay alive — about 21% of the air around you.',
     composition: { O: 2 },
     atoms: [
@@ -175,7 +187,7 @@ export const MOLECULES: Molecule[] = [
     bonds: [{ a: 0, b: 1, order: 2 }],
   },
   {
-    formula: 'N₂', name: 'Nitrogen gas', nameEs: 'Nitrógeno gaseoso', color: '#818cf8',
+    formula: 'N₂', name: 'Nitrogen gas', nameEs: 'Nitrógeno gaseoso', nameIt: 'Azoto gassoso', namePt: 'Nitrogênio gasoso', color: '#818cf8',
     description: 'About 78% of the air. Inert and often used to keep food fresh.',
     composition: { N: 2 },
     atoms: [
@@ -185,7 +197,7 @@ export const MOLECULES: Molecule[] = [
     bonds: [{ a: 0, b: 1, order: 3 }],
   },
   {
-    formula: 'H₂O₂', name: 'Hydrogen peroxide', nameEs: 'Peróxido de hidrógeno', color: '#bae6fd',
+    formula: 'H₂O₂', name: 'Hydrogen peroxide', nameEs: 'Peróxido de hidrógeno', nameIt: 'Perossido di idrogeno', namePt: 'Peróxido de hidrogênio', color: '#bae6fd',
     description: 'A pale blue liquid used to disinfect wounds and bleach hair — water with one extra oxygen.',
     composition: { H: 2, O: 2 },
     atoms: [
@@ -197,7 +209,7 @@ export const MOLECULES: Molecule[] = [
     bonds: [{ a: 0, b: 1, order: 1 }, { a: 0, b: 2, order: 1 }, { a: 1, b: 3, order: 1 }],
   },
   {
-    formula: 'O₃', name: 'Ozone', nameEs: 'Ozono', color: '#fca5a5',
+    formula: 'O₃', name: 'Ozone', nameEs: 'Ozono', nameIt: 'Ozono', namePt: 'Ozônio', color: '#fca5a5',
     description: 'High in the atmosphere it shields us from UV rays; at ground level it is a pollutant.',
     composition: { O: 3 },
     atoms: [
@@ -208,7 +220,7 @@ export const MOLECULES: Molecule[] = [
     bonds: [{ a: 0, b: 1, order: 2 }, { a: 0, b: 2, order: 1 }],
   },
   {
-    formula: 'CO', name: 'Carbon monoxide', nameEs: 'Monóxido de carbono', color: '#cbd5e1',
+    formula: 'CO', name: 'Carbon monoxide', nameEs: 'Monóxido de carbono', nameIt: 'Monossido di carbonio', namePt: 'Monóxido de carbono', color: '#cbd5e1',
     description: 'A colorless, odorless and toxic gas from incomplete burning of fuels.',
     composition: { C: 1, O: 1 },
     atoms: [
@@ -218,7 +230,7 @@ export const MOLECULES: Molecule[] = [
     bonds: [{ a: 0, b: 1, order: 3 }],
   },
   {
-    formula: 'NO', name: 'Nitric oxide', nameEs: 'Óxido nítrico', color: '#c7d2fe',
+    formula: 'NO', name: 'Nitric oxide', nameEs: 'Óxido nítrico', nameIt: 'Ossido nitrico', namePt: 'Óxido nítrico', color: '#c7d2fe',
     description: 'A signaling molecule in your body that relaxes blood vessels and controls blood flow.',
     composition: { N: 1, O: 1 },
     atoms: [
@@ -228,7 +240,7 @@ export const MOLECULES: Molecule[] = [
     bonds: [{ a: 0, b: 1, order: 2 }],
   },
   {
-    formula: 'SO₂', name: 'Sulfur dioxide', nameEs: 'Dióxido de azufre', color: '#fde047',
+    formula: 'SO₂', name: 'Sulfur dioxide', nameEs: 'Dióxido de azufre', nameIt: 'Anidride solforosa', namePt: 'Dióxido de enxofre', color: '#fde047',
     description: 'A sharp-smelling gas from volcanoes and burning coal; used to preserve dried fruit.',
     composition: { S: 1, O: 2 },
     atoms: [
@@ -239,7 +251,7 @@ export const MOLECULES: Molecule[] = [
     bonds: [{ a: 0, b: 1, order: 2 }, { a: 0, b: 2, order: 2 }],
   },
   {
-    formula: 'H₂S', name: 'Hydrogen sulfide', nameEs: 'Sulfuro de hidrógeno', color: '#fef08a',
+    formula: 'H₂S', name: 'Hydrogen sulfide', nameEs: 'Sulfuro de hidrógeno', nameIt: 'Solfuro di idrogeno', namePt: 'Sulfeto de hidrogênio', color: '#fef08a',
     description: 'The "rotten egg" gas, toxic in high amounts and produced by decaying matter.',
     composition: { H: 2, S: 1 },
     atoms: [
@@ -250,7 +262,7 @@ export const MOLECULES: Molecule[] = [
     bonds: [{ a: 0, b: 1, order: 1 }, { a: 0, b: 2, order: 1 }],
   },
   {
-    formula: 'HF', name: 'Hydrogen fluoride', nameEs: 'Fluoruro de hidrógeno', color: '#bef264',
+    formula: 'HF', name: 'Hydrogen fluoride', nameEs: 'Fluoruro de hidrógeno', nameIt: 'Fluoruro di idrogeno', namePt: 'Fluoreto de hidrogênio', color: '#bef264',
     description: 'Dissolved in water it becomes hydrofluoric acid, used to etch glass and silicon.',
     composition: { H: 1, F: 1 },
     atoms: [
@@ -260,7 +272,7 @@ export const MOLECULES: Molecule[] = [
     bonds: [{ a: 0, b: 1, order: 1 }],
   },
   {
-    formula: 'PH₃', name: 'Phosphine', nameEs: 'Fosfina', color: '#fdba74',
+    formula: 'PH₃', name: 'Phosphine', nameEs: 'Fosfina', nameIt: 'Fosfina', namePt: 'Fosfina', color: '#fdba74',
     description: 'A toxic, flammable gas with a garlic-like smell, used in the semiconductor industry.',
     composition: { P: 1, H: 3 },
     atoms: [
@@ -275,7 +287,7 @@ export const MOLECULES: Molecule[] = [
   // --- Productos de 2º nivel (árbol de alquimia: se craftean combinando otras
   //     moléculas, no átomos sueltos). Ver ALCHEMY_RECIPES. ---
   {
-    formula: 'H₂CO₃', name: 'Carbonic acid', nameEs: 'Ácido carbónico', color: '#67e8f9',
+    formula: 'H₂CO₃', name: 'Carbonic acid', nameEs: 'Ácido carbónico', nameIt: 'Acido carbonico', namePt: 'Ácido carbônico', color: '#67e8f9',
     description: 'Forms when CO₂ dissolves in water — it is what makes soda fizzy and rain slightly acidic.',
     composition: { H: 2, C: 1, O: 3 }, compound: true,
     atoms: [
@@ -292,7 +304,7 @@ export const MOLECULES: Molecule[] = [
     ],
   },
   {
-    formula: 'NH₄Cl', name: 'Ammonium chloride', nameEs: 'Cloruro de amonio', color: '#c4b5fd',
+    formula: 'NH₄Cl', name: 'Ammonium chloride', nameEs: 'Cloruro de amonio', nameIt: 'Cloruro di ammonio', namePt: 'Cloreto de amônio', color: '#c4b5fd',
     description: 'A salt of ammonia and hydrochloric acid, used in fertilizers, batteries and cough medicine.',
     composition: { N: 1, H: 4, Cl: 1 }, compound: true,
     atoms: [
@@ -309,7 +321,7 @@ export const MOLECULES: Molecule[] = [
     ],
   },
   {
-    formula: 'H₂SO₃', name: 'Sulfurous acid', nameEs: 'Ácido sulfuroso', color: '#fef9c3',
+    formula: 'H₂SO₃', name: 'Sulfurous acid', nameEs: 'Ácido sulfuroso', nameIt: 'Acido solforoso', namePt: 'Ácido sulfuroso', color: '#fef9c3',
     description: 'Forms when sulfur dioxide dissolves in water; the chemistry behind acid rain.',
     composition: { H: 2, S: 1, O: 3 }, compound: true,
     atoms: [
@@ -326,7 +338,7 @@ export const MOLECULES: Molecule[] = [
     ],
   },
   {
-    formula: 'NH₄OH', name: 'Ammonium hydroxide', nameEs: 'Hidróxido de amonio', color: '#ddd6fe',
+    formula: 'NH₄OH', name: 'Ammonium hydroxide', nameEs: 'Hidróxido de amonio', nameIt: 'Idrossido di ammonio', namePt: 'Hidróxido de amônio', color: '#ddd6fe',
     description: 'Ammonia dissolved in water — the cloudy "ammonia" sold as a household cleaner.',
     composition: { N: 1, H: 5, O: 1 }, compound: true,
     atoms: [
@@ -458,15 +470,34 @@ export function brew(c: Cauldron): Molecule | null {
   return recipe ? BY_FORMULA[recipe.output] ?? null : null;
 }
 
-/** Etiqueta legible de un ingrediente (nombre en español si es producto). */
-export function ingredientLabel(id: IngredientId): string {
-  if (id in ELEMENTS) return ELEMENTS[id as ElementSymbol].nameEs;
-  return BY_FORMULA[id]?.nameEs ?? id;
+/** Algo con nombre en los 4 idiomas (elemento o molécula). */
+type Named = { name: string; nameEs: string; nameIt: string; namePt: string };
+
+/** Nombre de un elemento o molécula en el idioma dado (inglés por defecto). */
+export function localizedName(e: Named, lang: Lang): string {
+  switch (lang) {
+    case 'es': return e.nameEs;
+    case 'it': return e.nameIt;
+    case 'pt': return e.namePt;
+    default: return e.name;
+  }
+}
+
+/** Los 4 nombres de un elemento o molécula (para el match de voz multi-idioma). */
+export function allNames(e: Named): string[] {
+  return [e.name, e.nameEs, e.nameIt, e.namePt];
+}
+
+/** Etiqueta legible de un ingrediente en el idioma dado. */
+export function ingredientLabel(id: IngredientId, lang: Lang): string {
+  if (isElement(id)) return localizedName(ELEMENTS[id], lang);
+  const m = BY_FORMULA[id];
+  return m ? localizedName(m, lang) : id;
 }
 
 /** ¿Este ingrediente es un átomo (elemento de la tabla)? */
 export function isElement(id: IngredientId): id is ElementSymbol {
-  return id in ELEMENTS;
+  return Object.prototype.hasOwnProperty.call(ELEMENTS, id);
 }
 
 /** Molécula por fórmula, o undefined si no existe. */

--- a/src/i18n.test.ts
+++ b/src/i18n.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { t, detectLang, LANGS, LANG_LABEL, type UIKey } from './i18n';
+
+describe('detectLang', () => {
+  it('mapea un tag BCP-47 al idioma soportado', () => {
+    expect(detectLang('es-AR')).toBe('es');
+    expect(detectLang('pt-BR')).toBe('pt');
+    expect(detectLang('it')).toBe('it');
+    expect(detectLang('en-US')).toBe('en');
+  });
+
+  it('cae a inglés para idiomas no soportados o vacíos', () => {
+    expect(detectLang('fr')).toBe('en');
+    expect(detectLang('')).toBe('en');
+    expect(detectLang(null)).toBe('en');
+    expect(detectLang(undefined)).toBe('en');
+  });
+});
+
+describe('catálogo de strings', () => {
+  // Las claves que el código usa; si falta una traducción, t() devolvería undefined.
+  const KEYS: UIKey[] = [
+    'title', 'lead', 'start', 'privacy', 'statusIdle', 'statusWarmup', 'statusReady',
+    'statusCam', 'statusErr', 'cauldron', 'cauldronHint', 'mix', 'empty',
+    'inventory', 'inventoryEmpty', 'voiceHint', 'emptyCauldron', 'noReaction',
+    'emptied', 'freeHand', 'nothingInHand', 'handLeft', 'handRight', 'hands',
+  ];
+
+  it('los 4 idiomas tienen todas las claves con texto no vacío', () => {
+    for (const lang of LANGS) {
+      for (const key of KEYS) {
+        expect(t(lang, key).trim().length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('hay etiqueta de selector para cada idioma', () => {
+    for (const lang of LANGS) expect(LANG_LABEL[lang]).toMatch(/^[A-Z]{2}$/);
+  });
+});

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,153 @@
+/**
+ * Internacionalización: textos de UI en los 4 idiomas soportados. Puro (sin DOM),
+ * para poder testearlo y reusarlo desde el dominio. Los nombres de elementos y
+ * moléculas viven en `chemistry.ts` (uno por idioma); acá solo el chrome de la UI.
+ */
+
+export type Lang = 'es' | 'en' | 'it' | 'pt';
+export const LANGS: Lang[] = ['es', 'en', 'it', 'pt'];
+
+/** Etiqueta corta para el selector de idioma. */
+export const LANG_LABEL: Record<Lang, string> = { es: 'ES', en: 'EN', it: 'IT', pt: 'PT' };
+
+/** Bandera (emoji) por idioma. Ojo: en Windows/Chrome no renderiza como bandera. */
+export const LANG_FLAG: Record<Lang, string> = { es: '🇪🇸', en: '🇬🇧', it: '🇮🇹', pt: '🇧🇷' };
+
+/**
+ * Banderas como SVG inline (simplificadas pero reconocibles). A diferencia del
+ * emoji, se ven igual en todos los sistemas. Markup propio, seguro para innerHTML.
+ */
+export const LANG_FLAG_SVG: Record<Lang, string> = {
+  es: '<svg viewBox="0 0 3 2" aria-hidden="true"><rect width="3" height="2" fill="#c60b1e"/><rect y="0.5" width="3" height="1" fill="#ffc400"/></svg>',
+  en: '<svg viewBox="0 0 60 30" aria-hidden="true"><rect width="60" height="30" fill="#012169"/><path d="M0,0 60,30 M60,0 0,30" stroke="#fff" stroke-width="6"/><path d="M0,0 60,30 M60,0 0,30" stroke="#c8102e" stroke-width="4"/><path d="M30,0 v30 M0,15 h60" stroke="#fff" stroke-width="10"/><path d="M30,0 v30 M0,15 h60" stroke="#c8102e" stroke-width="6"/></svg>',
+  it: '<svg viewBox="0 0 3 2" aria-hidden="true"><rect width="3" height="2" fill="#fff"/><rect width="1" height="2" fill="#009246"/><rect x="2" width="1" height="2" fill="#ce2b37"/></svg>',
+  pt: '<svg viewBox="0 0 20 14" aria-hidden="true"><rect width="20" height="14" fill="#009b3a"/><polygon points="10,1.5 18.5,7 10,12.5 1.5,7" fill="#ffdf00"/><circle cx="10" cy="7" r="2.6" fill="#002776"/></svg>',
+};
+
+/** Nombre del idioma en su propia lengua (para que sea obvio, aunque la bandera no renderice). */
+export const LANG_NAME: Record<Lang, string> = { es: 'Español', en: 'English', it: 'Italiano', pt: 'Português' };
+
+export type UIKey =
+  | 'title' | 'lead' | 'start' | 'privacy' | 'statusIdle' | 'statusWarmup' | 'statusReady'
+  | 'statusCam' | 'statusErr'
+  | 'cauldron' | 'cauldronHint' | 'mix' | 'empty' | 'inventory' | 'inventoryEmpty'
+  | 'voiceHint' | 'emptyCauldron' | 'noReaction' | 'emptied' | 'freeHand'
+  | 'nothingInHand' | 'handLeft' | 'handRight' | 'hands';
+
+const STRINGS: Record<Lang, Record<UIKey, string>> = {
+  es: {
+    title: 'Cuenco de Alquimia',
+    lead: 'Activá la cámara para jugar.',
+    start: 'Activar cámara',
+    privacy: '🔒 Corre en tu dispositivo · tu cámara nunca sale de acá',
+    statusIdle: 'No se carga nada hasta que empieces.',
+    statusWarmup: 'Preparando el modelo…',
+    statusReady: '✨ Listo — tocá empezar',
+    statusCam: 'Pidiendo la cámara…',
+    statusErr: 'No se pudo acceder a la cámara. Revisá permisos y recargá.',
+    cauldron: '⚗ Cuenco',
+    cauldronHint: 'acercá un átomo',
+    mix: '✨ Mezclar',
+    empty: '🗑 Vaciar',
+    inventory: 'Inventario',
+    inventoryEmpty: 'todavía no creaste nada — combiná átomos en el cuenco',
+    voiceHint: 'decí: átomo · “echar” · “mezclar” · “vaciar”',
+    emptyCauldron: 'Cuenco vacío',
+    noReaction: 'No reacciona',
+    emptied: 'Vaciado',
+    freeHand: 'mostrá una mano libre',
+    nothingInHand: 'Nada en',
+    handLeft: 'la mano izquierda',
+    handRight: 'la mano derecha',
+    hands: 'tus manos',
+  },
+  en: {
+    title: 'Alchemy Cauldron',
+    lead: 'Enable your camera to play.',
+    start: 'Enable camera',
+    privacy: '🔒 Runs on your device · your camera never leaves it',
+    statusIdle: 'Nothing loads until you start.',
+    statusWarmup: 'Warming up the model…',
+    statusReady: '✨ Ready — tap to start',
+    statusCam: 'Requesting the camera…',
+    statusErr: "Couldn't access the camera. Check permissions and reload.",
+    cauldron: '⚗ Cauldron',
+    cauldronHint: 'bring an atom closer',
+    mix: '✨ Mix',
+    empty: '🗑 Empty',
+    inventory: 'Inventory',
+    inventoryEmpty: "you haven't made anything yet — combine atoms in the cauldron",
+    voiceHint: 'say: atom · “drop” · “mix” · “empty”',
+    emptyCauldron: 'Empty cauldron',
+    noReaction: 'No reaction',
+    emptied: 'Emptied',
+    freeHand: 'show a free hand',
+    nothingInHand: 'Nothing in',
+    handLeft: 'the left hand',
+    handRight: 'the right hand',
+    hands: 'your hands',
+  },
+  it: {
+    title: 'Calderone Alchemico',
+    lead: 'Attiva la fotocamera per giocare.',
+    start: 'Attiva fotocamera',
+    privacy: '🔒 Gira sul tuo dispositivo · la fotocamera non esce mai da qui',
+    statusIdle: 'Non si carica niente finché non inizi.',
+    statusWarmup: 'Preparazione del modello…',
+    statusReady: '✨ Pronto — tocca per iniziare',
+    statusCam: 'Richiesta della fotocamera…',
+    statusErr: "Impossibile accedere alla fotocamera. Controlla i permessi e ricarica.",
+    cauldron: '⚗ Calderone',
+    cauldronHint: 'avvicina un atomo',
+    mix: '✨ Mescola',
+    empty: '🗑 Svuota',
+    inventory: 'Inventario',
+    inventoryEmpty: 'non hai ancora creato niente — combina atomi nel calderone',
+    voiceHint: 'dì: atomo · “metti” · “mescola” · “svuota”',
+    emptyCauldron: 'Calderone vuoto',
+    noReaction: 'Nessuna reazione',
+    emptied: 'Svuotato',
+    freeHand: 'mostra una mano libera',
+    nothingInHand: 'Niente in',
+    handLeft: 'la mano sinistra',
+    handRight: 'la mano destra',
+    hands: 'le tue mani',
+  },
+  pt: {
+    title: 'Caldeirão de Alquimia',
+    lead: 'Ative a câmera para jogar.',
+    start: 'Ativar câmera',
+    privacy: '🔒 Roda no seu dispositivo · sua câmera nunca sai daqui',
+    statusIdle: 'Nada carrega até você começar.',
+    statusWarmup: 'Preparando o modelo…',
+    statusReady: '✨ Pronto — toque para começar',
+    statusCam: 'Pedindo a câmera…',
+    statusErr: 'Não foi possível acessar a câmera. Verifique as permissões e recarregue.',
+    cauldron: '⚗ Caldeirão',
+    cauldronHint: 'aproxime um átomo',
+    mix: '✨ Misturar',
+    empty: '🗑 Esvaziar',
+    inventory: 'Inventário',
+    inventoryEmpty: 'você ainda não criou nada — combine átomos no caldeirão',
+    voiceHint: 'diga: átomo · “jogar” · “misturar” · “esvaziar”',
+    emptyCauldron: 'Caldeirão vazio',
+    noReaction: 'Sem reação',
+    emptied: 'Esvaziado',
+    freeHand: 'mostre uma mão livre',
+    nothingInHand: 'Nada em',
+    handLeft: 'a mão esquerda',
+    handRight: 'a mão direita',
+    hands: 'suas mãos',
+  },
+};
+
+/** Texto de UI para un idioma y clave. */
+export function t(lang: Lang, key: UIKey): string {
+  return STRINGS[lang][key];
+}
+
+/** Detecta el idioma soportado a partir de un tag BCP-47 (ej. "pt-BR" → "pt"). */
+export function detectLang(raw: string | null | undefined): Lang {
+  const base = (raw ?? '').trim().toLowerCase().split('-')[0];
+  return (LANGS as string[]).includes(base) ? (base as Lang) : 'en';
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -10,9 +10,6 @@ export const LANGS: Lang[] = ['es', 'en', 'it', 'pt'];
 /** Etiqueta corta para el selector de idioma. */
 export const LANG_LABEL: Record<Lang, string> = { es: 'ES', en: 'EN', it: 'IT', pt: 'PT' };
 
-/** Bandera (emoji) por idioma. Ojo: en Windows/Chrome no renderiza como bandera. */
-export const LANG_FLAG: Record<Lang, string> = { es: '🇪🇸', en: '🇬🇧', it: '🇮🇹', pt: '🇧🇷' };
-
 /**
  * Banderas como SVG inline (simplificadas pero reconocibles). A diferencia del
  * emoji, se ven igual en todos los sistemas. Markup propio, seguro para innerHTML.

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,8 @@ import {
   findMolecule,
   isElement,
   ingredientLabel,
+  localizedName,
+  allNames,
   ELEMENTS,
   ELEMENT_ORDER,
   MOLECULES,
@@ -16,8 +18,9 @@ import {
 import { HandTracker, LM, type Hand } from './hands';
 import { ParticleSystem } from './particles';
 import { drawAtom, drawMolecule } from './structure';
-import { VoiceRecognizer, type ProductLexEntry } from './voice';
+import { VoiceRecognizer, resolveLang, type ProductLexEntry, type VoiceCommand } from './voice';
 import { createInventory } from './inventory';
+import { t, LANGS, LANG_LABEL, LANG_FLAG_SVG, LANG_NAME, type Lang } from './i18n';
 
 // ---------------------------------------------------------------------------
 // Constantes
@@ -31,7 +34,10 @@ const SHELF_MAX = 12;        // celdas visibles del estante (las más recientes)
 const COOLDOWN_MS = 1200;    // entre mezclas
 const MAX_COUNT = 6;
 const MAX_FLOATING = 10;
-const VOICE_LANG = 'es-AR';  // el juego es español-first
+
+// Idioma de la UI y del reconocimiento de voz. Por defecto inglés; el jugador lo
+// cambia con el selector de banderas (visible siempre, también dentro del juego).
+let lang: Lang = 'en';
 
 // ---------------------------------------------------------------------------
 // DOM
@@ -74,10 +80,10 @@ let modelReady: Promise<boolean> | null = null;
 
 function preloadModel(): Promise<boolean> {
   if (!modelReady) {
-    statusEl.textContent = 'Preparando el modelo…';
+    statusEl.textContent = t(lang, 'statusWarmup');
     modelReady = tracker.init().then(
-      () => { statusEl.textContent = '✨ Listo — tocá empezar'; return true; },
-      (err) => { console.error(err); statusEl.textContent = 'El modelo no cargó. Recargá para reintentar.'; return false; },
+      () => { statusEl.textContent = t(lang, 'statusReady'); return true; },
+      (err) => { console.error(err); statusEl.textContent = t(lang, 'statusErr'); return false; },
     );
   }
   return modelReady;
@@ -87,6 +93,49 @@ function preloadModel(): Promise<boolean> {
 startBtn.addEventListener('pointerenter', preloadModel, { once: true });
 startBtn.addEventListener('pointerdown', preloadModel, { once: true });
 startBtn.addEventListener('focus', preloadModel, { once: true });
+
+// ---------------------------------------------------------------------------
+// Selector de idioma (overlay): cambia el HUD y el locale del reconocedor de voz
+// ---------------------------------------------------------------------------
+const langsEl = document.querySelector<HTMLDivElement>('#langs');       // overlay: bandera + nombre
+const langbarEl = document.querySelector<HTMLDivElement>('#langbar');   // persistente in-game: bandera + código
+const titleEl = document.querySelector<HTMLHeadingElement>('#title');
+const leadEl = document.querySelector<HTMLParagraphElement>('.lead');
+const privacyEl = document.querySelector<HTMLParagraphElement>('.privacy');
+
+/** Aplica un idioma: textos del overlay, botones y —si ya se está jugando— la voz. */
+function applyLang(l: Lang) {
+  const changed = l !== lang;
+  lang = l;
+  document.documentElement.lang = l;
+  if (titleEl) titleEl.textContent = t(l, 'title');
+  if (leadEl) leadEl.textContent = t(l, 'lead');
+  startBtn.textContent = t(l, 'start');
+  if (privacyEl) privacyEl.textContent = t(l, 'privacy');
+  // El status solo se pisa si seguimos en la pantalla idle (sin warmup en curso).
+  if (!running && !modelReady) statusEl.textContent = t(l, 'statusIdle');
+  renderLangButtons();
+  // En vivo, reiniciamos el reconocedor para que escuche en el nuevo idioma.
+  if (changed && running && voiceListening) restartVoice();
+}
+
+function makeLangButton(l: Lang, full: boolean): HTMLButtonElement {
+  const b = document.createElement('button');
+  b.type = 'button';
+  b.className = 'lang' + (l === lang ? ' active' : '');
+  b.setAttribute('aria-pressed', String(l === lang));
+  // Bandera SVG (markup propio, seguro) + nombre nativo o código.
+  b.innerHTML = `<span class="flag">${LANG_FLAG_SVG[l]}</span><span class="lang-name">${full ? LANG_NAME[l] : LANG_LABEL[l]}</span>`;
+  b.addEventListener('click', () => applyLang(l));
+  return b;
+}
+
+function renderLangButtons() {
+  if (langsEl) langsEl.replaceChildren(...LANGS.map((l) => makeLangButton(l, true)));
+  if (langbarEl) langbarEl.replaceChildren(...LANGS.map((l) => makeLangButton(l, false)));
+}
+
+applyLang(lang); // el overlay arranca en inglés (default), pisando el HTML estático
 
 // ---------------------------------------------------------------------------
 // Estado de juego
@@ -140,6 +189,22 @@ let infoTimer: ReturnType<typeof setTimeout> | undefined;
 const voice = new VoiceRecognizer();
 let voiceListening = false;
 
+/** Arranca la escucha de voz en el idioma actual. Devuelve si quedó activa. */
+function startVoice(): boolean {
+  return VoiceRecognizer.supported && voice.start({
+    onElement: giveIngredient,
+    onProduct: giveIngredient,
+    onCommand: handleVoiceCommand,
+    getProducts: productLexicon,
+  }, resolveLang(lang));
+}
+
+/** Reinicia la voz (al cambiar de idioma en vivo) para escuchar en el nuevo locale. */
+function restartVoice() {
+  voice.stop();
+  voiceListening = startVoice();
+}
+
 // ---------------------------------------------------------------------------
 // Arranque
 // ---------------------------------------------------------------------------
@@ -147,15 +212,31 @@ startBtn.addEventListener('click', () => start());
 
 let camStream: MediaStream | null = null;
 
+/**
+ * Pide cámara y —si el navegador soporta voz— micrófono en UN SOLO prompt, para
+ * no encadenar dos permisos (cámara y después el del reconocimiento de voz). Si
+ * el micrófono no está disponible/permitido, reintenta solo con la cámara: el
+ * juego sigue funcionando por gestos.
+ */
+async function requestMedia(): Promise<MediaStream> {
+  const video = { facingMode: 'user', width: { ideal: 960 }, height: { ideal: 540 }, frameRate: { ideal: 30 } };
+  const wantsMic = VoiceRecognizer.supported;
+  try {
+    return await navigator.mediaDevices.getUserMedia({ video, audio: wantsMic });
+  } catch (err) {
+    if (!wantsMic) throw err;
+    return await navigator.mediaDevices.getUserMedia({ video, audio: false });
+  }
+}
+
 async function start() {
   startBtn.disabled = true;
   try {
-    statusEl.textContent = 'Pidiendo la cámara…';
-    const stream = await navigator.mediaDevices.getUserMedia({
-      video: { facingMode: 'user', width: { ideal: 960 }, height: { ideal: 540 }, frameRate: { ideal: 30 } },
-      audio: false,
-    });
+    statusEl.textContent = t(lang, 'statusCam');
+    const stream = await requestMedia();
     camStream = stream;
+    // Solo el video alimenta el tracking; el track de audio (si lo hay) queda
+    // abierto únicamente para que el reconocimiento de voz reuse el permiso.
     video.srcObject = stream;
     await video.play();
 
@@ -169,17 +250,12 @@ async function start() {
     lastTime = performance.now();
     requestAnimationFrame(loop);
 
-    // Escucha de voz (pide micrófono; si falla, se juega con gestos).
-    voiceListening = VoiceRecognizer.supported && voice.start({
-      onElement: giveIngredient,
-      onProduct: giveIngredient,
-      onCommand: () => mezclar(),
-      getProducts: productLexicon,
-    }, VOICE_LANG);
+    // Escucha de voz (el permiso de micrófono ya se pidió junto al de cámara).
+    voiceListening = startVoice();
   } catch (err) {
     console.error(err);
     stopCamera();
-    statusEl.textContent = 'No se pudo acceder a la cámara. Revisá permisos y recargá.';
+    statusEl.textContent = t(lang, 'statusErr');
     statusEl.classList.add('error');
     startBtn.disabled = false;
   }
@@ -460,7 +536,7 @@ function mezclar() {
   if (cooldown !== 0) return;
   const c = cauldronGeo();
   if (!cauldronHasContents()) {
-    pushToast('Cuenco vacío', '#94a3b8', c.cx, c.cy);
+    pushToast(t(lang, 'emptyCauldron'), '#94a3b8', c.cx, c.cy);
     return;
   }
   cooldown = COOLDOWN_MS;
@@ -468,7 +544,7 @@ function mezclar() {
 
   if (!product) {
     particles.burst(c.cx, c.cy, '#64748b', 50, 320 * DPR);
-    pushToast('No reacciona', '#94a3b8', c.cx, c.cy);
+    pushToast(t(lang, 'noReaction'), '#94a3b8', c.cx, c.cy);
     playChime(false);
     return; // conservamos el contenido para que puedas ajustar
   }
@@ -477,7 +553,7 @@ function mezclar() {
   playChime(true);
   spawnFloating(product, c.cx / canvas.width, (c.cy - c.r * 0.8) / canvas.height);
   const isNew = inventory.add(product.formula);
-  pushToast(`${product.nameEs}${isNew ? ' ✦' : ''}`, product.color, c.cx, c.cy - c.r * 0.6);
+  pushToast(`${localizedName(product, lang)}${isNew ? ' ✦' : ''}`, product.color, c.cx, c.cy - c.r * 0.6);
   clearContents();
   showInfo(product, isNew);
 }
@@ -487,9 +563,35 @@ function clearCauldron() {
   if (!cauldronHasContents()) return;
   const c = cauldronGeo();
   particles.burst(c.cx, c.cy, '#94a3b8', 24, 240 * DPR);
-  pushToast('Vaciado', '#94a3b8', c.cx, c.cy);
+  pushToast(t(lang, 'emptied'), '#94a3b8', c.cx, c.cy);
   clearContents();
   playChime(false);
+}
+
+/** Despacha una orden de voz a la acción correspondiente. */
+function handleVoiceCommand(c: VoiceCommand) {
+  if (c === 'mix') mezclar();
+  else if (c === 'clear') clearCauldron();
+  else if (c === 'deposit') depositByVoice('any');
+  else if (c === 'deposit-left') depositByVoice('Left');
+  else if (c === 'deposit-right') depositByVoice('Right');
+}
+
+/**
+ * Deposita por voz lo que sostiene una mano (o cualquiera) en el cuenco, sin
+ * tener que acercarla físicamente. `'any'` vacía las dos manos que tengan algo.
+ */
+function depositByVoice(which: SlotName | 'any') {
+  const slots: SlotName[] = which === 'any' ? ['Right', 'Left'] : [which];
+  let did = false;
+  for (const n of slots) {
+    const st = hands[n];
+    if (st.held && st.count > 0) { deposit(st); did = true; }
+  }
+  if (!did) {
+    const where = which === 'Left' ? t(lang, 'handLeft') : which === 'Right' ? t(lang, 'handRight') : t(lang, 'hands');
+    pushToast(`${t(lang, 'nothingInHand')} ${where}`, '#94a3b8', canvas.width / 2, canvas.height * 0.42);
+  }
 }
 
 function clearContents() {
@@ -528,7 +630,7 @@ function giveIngredient(id: IngredientId) {
       return;
     }
   }
-  pushToast(`${label} — mostrá una mano libre`, color, canvas.width / 2, canvas.height * 0.42);
+  pushToast(`${label} — ${t(lang, 'freeHand')}`, color, canvas.width / 2, canvas.height * 0.42);
 }
 
 function ingredientFeedback(st: HandState, color: string, label: string) {
@@ -537,12 +639,12 @@ function ingredientFeedback(st: HandState, color: string, label: string) {
   playChime(true);
 }
 
-/** Productos invocables por voz ahora: solo los ya descubiertos (nombre ES/EN). */
+/** Productos invocables por voz ahora: solo los ya descubiertos (nombres en 4 idiomas). */
 function productLexicon(): ProductLexEntry[] {
   const out: ProductLexEntry[] = [];
   for (const formula of inventory.list()) {
     const m = findMolecule(formula);
-    if (m) out.push({ id: formula, names: [m.nameEs, m.name] });
+    if (m) out.push({ id: formula, names: allNames(m) });
   }
   return out;
 }
@@ -586,16 +688,16 @@ function showInfo(m: Molecule, isNew: boolean) {
     .filter((s) => (m.composition[s] ?? 0) > 0)
     .map((s) => {
       const el = ELEMENTS[s];
-      return `<li><b style="color:${el.color}">${el.symbol}</b> ${el.nameEs} · Z=${el.atomicNumber} · ×${m.composition[s]}</li>`;
+      return `<li><b style="color:${el.color}">${el.symbol}</b> ${localizedName(el, lang)} · Z=${el.atomicNumber} · ×${m.composition[s]}</li>`;
     })
     .join('');
   infoEl.innerHTML = `
     <div class="info-head" style="--accent:${m.color}">
       <span class="info-formula">${m.formula}</span>
-      <span class="info-name">${m.nameEs}${isNew ? ' ✦' : ''}</span>
+      <span class="info-name">${localizedName(m, lang)}${isNew ? ' ✦' : ''}</span>
     </div>
     <p class="info-desc">${m.description}</p>
-    <div class="info-recipe">Composición: <b>${recipeText(m.composition)}</b></div>
+    <div class="info-recipe">${recipeText(m.composition)}</div>
     <ul class="info-elements">${elems}</ul>`;
   infoEl.classList.remove('hidden');
   clearTimeout(infoTimer);
@@ -697,10 +799,10 @@ function drawCauldron(time: number) {
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
     ctx.font = `700 ${Math.min(r * 0.16, 26 * DPR)}px system-ui, sans-serif`;
-    ctx.fillText('⚗ Cuenco', cx, cy - r * 0.08);
+    ctx.fillText(t(lang, 'cauldron'), cx, cy - r * 0.08);
     ctx.fillStyle = 'rgba(186,200,220,0.95)';
     ctx.font = `500 ${Math.min(r * 0.1, 15 * DPR)}px system-ui, sans-serif`;
-    ctx.fillText('acercá un átomo', cx, cy + r * 0.16);
+    ctx.fillText(t(lang, 'cauldronHint'), cx, cy + r * 0.16);
     return;
   }
 
@@ -728,7 +830,7 @@ function drawCauldron(time: number) {
   });
 
   // Etiqueta de receta en el centro.
-  const label = ids.map((id) => `${(contents[id] ?? 0) > 1 ? `${contents[id]} ` : ''}${ingredientLabel(id)}`).join(' + ');
+  const label = ids.map((id) => `${(contents[id] ?? 0) > 1 ? `${contents[id]} ` : ''}${ingredientLabel(id, lang)}`).join(' + ');
   ctx.fillStyle = '#e2e8f0';
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
@@ -777,13 +879,13 @@ function drawButton(rect: Rect, label: string, accent: string, progress: number,
 function drawMixButton() {
   const rect = mixButtonRect();
   const progress = Math.max(hands.Left.mixMs, hands.Right.mixMs) / MIX_DWELL_MS;
-  drawButton(rect, '✨ Mezclar', '#fbbf24', progress, cauldronHasContents() && cooldown === 0);
+  drawButton(rect, t(lang, 'mix'), '#fbbf24', progress, cauldronHasContents() && cooldown === 0);
 }
 
 function drawClearButton() {
   const rect = clearButtonRect();
   const progress = Math.max(hands.Left.clearMs, hands.Right.clearMs) / CLEAR_DWELL_MS;
-  drawButton(rect, '🗑 Vaciar', '#f87171', progress, cauldronHasContents());
+  drawButton(rect, t(lang, 'empty'), '#f87171', progress, cauldronHasContents());
 }
 
 function drawFloating() {
@@ -822,7 +924,7 @@ function drawPalette(time: number) {
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
     ctx.font = `600 ${t.size * 0.13}px system-ui, sans-serif`;
-    ctx.fillText(el.nameEs, t.x + t.size / 2, t.y + t.size * 0.88);
+    ctx.fillText(localizedName(el, lang), t.x + t.size / 2, t.y + t.size * 0.88);
   }
   // Anillo de progreso de dwell sobre el tile en foco.
   for (const name of ['Left', 'Right'] as SlotName[]) {
@@ -854,12 +956,12 @@ function drawShelf(time: number) {
   ctx.textBaseline = 'middle';
   ctx.fillStyle = 'rgba(226,232,240,0.9)';
   ctx.font = `700 ${14 * DPR}px system-ui, sans-serif`;
-  ctx.fillText(`Inventario (${total})`, pad, labelY);
+  ctx.fillText(`${t(lang, 'inventory')} (${total})`, pad, labelY);
 
   if (cells.length === 0) {
     ctx.fillStyle = 'rgba(148,163,184,0.8)';
     ctx.font = `500 ${13 * DPR}px system-ui, sans-serif`;
-    ctx.fillText('todavía no creaste nada — combiná átomos en el cuenco', pad, labelY + 22 * DPR);
+    ctx.fillText(t(lang, 'inventoryEmpty'), pad, labelY + 22 * DPR);
     return;
   }
 
@@ -907,7 +1009,7 @@ function drawVoiceHint() {
   ctx.fillText('🎙', x, y);
   ctx.fillStyle = 'rgba(226, 232, 240, 0.9)';
   ctx.font = `600 ${14 * DPR}px system-ui, sans-serif`;
-  ctx.fillText('decí un átomo o producto · “mezclar”', x + 26 * DPR, y);
+  ctx.fillText(t(lang, 'voiceHint'), x + 26 * DPR, y);
 }
 
 function drawHand(st: HandState, time: number) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -135,7 +135,8 @@ function renderLangButtons() {
   if (langbarEl) langbarEl.replaceChildren(...LANGS.map((l) => makeLangButton(l, false)));
 }
 
-applyLang(lang); // el overlay arranca en inglés (default), pisando el HTML estático
+// La pintada inicial del overlay (applyLang) se hace al final del módulo, una vez
+// declarado todo el estado (`running`, voz, etc.) que applyLang puede leer.
 
 // ---------------------------------------------------------------------------
 // Estado de juego
@@ -1090,6 +1091,11 @@ function idleLoop(now: number) {
   renderIdle(now / 1000);
   requestAnimationFrame(idleLoop);
 }
+
+// Pintada inicial del overlay en el idioma por defecto (inglés). Se hace acá, al
+// final del módulo, para que `running` y demás estado ya estén inicializados:
+// applyLang los lee y, antes, esto tiraba "Cannot access 'running' before init".
+applyLang(lang);
 
 // Moléculas de muestra flotando como ambiente.
 for (let i = 0; i < 3; i++) {

--- a/src/style.css
+++ b/src/style.css
@@ -61,6 +61,100 @@ body {
   backdrop-filter: blur(10px);
 }
 
+/* --- Selector de idioma --------------------------------------------------- */
+.lang-title {
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #8b97a8;
+  margin-bottom: 0.6rem;
+}
+
+/* Overlay: grilla 2×2, bandera + nombre nativo */
+.langs {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.5rem;
+  max-width: 21rem;
+  margin: 0 auto 1.6rem;
+}
+
+/* Barra persistente arriba a la derecha (también durante el juego) */
+.langbar {
+  position: fixed;
+  top: 0.85rem;
+  right: 0.85rem;
+  z-index: 9;
+  display: flex;
+  gap: 0.25rem;
+  padding: 0.28rem;
+  border-radius: 0.8rem;
+  background: rgba(8, 11, 20, 0.5);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  backdrop-filter: blur(8px);
+}
+
+.lang {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font: inherit;
+  font-weight: 600;
+  font-size: 0.9rem;
+  cursor: pointer;
+  padding: 0.45rem 0.7rem;
+  border-radius: 0.6rem;
+  color: #cbd5e1;
+  background: transparent;
+  border: 1px solid transparent;
+  transition: color 0.14s ease, background 0.14s ease, border-color 0.14s ease;
+}
+
+.langs .lang {
+  justify-content: flex-start;
+  background: rgba(15, 23, 42, 0.45);
+  border-color: rgba(148, 163, 184, 0.18);
+}
+
+.langbar .lang {
+  padding: 0.32rem 0.5rem;
+  font-size: 0.8rem;
+}
+
+.lang:hover {
+  color: #f1f5f9;
+  background: rgba(56, 189, 248, 0.12);
+  border-color: rgba(125, 211, 252, 0.45);
+}
+
+.lang.active {
+  color: #f8fafc;
+  background: rgba(56, 189, 248, 0.16);
+  border-color: rgba(125, 211, 252, 0.75);
+}
+
+/* Bandera SVG: chip redondeado, nítido, con un borde sutil */
+.flag {
+  display: inline-flex;
+  width: 1.45rem;
+  height: 1.05rem;
+  flex: none;
+  border-radius: 3px;
+  overflow: hidden;
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.18), 0 1px 2px rgba(0, 0, 0, 0.35);
+}
+
+.flag svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.lang-name {
+  line-height: 1;
+}
+
 .logo {
   font-size: 3rem;
   line-height: 1;

--- a/src/voice.test.ts
+++ b/src/voice.test.ts
@@ -28,6 +28,16 @@ describe('matchElement', () => {
     expect(matchElement('fósforo')).toBe('P');
   });
 
+  it('reconoce nombres en italiano y portugués', () => {
+    expect(matchElement('idrogeno')).toBe('H');   // it
+    expect(matchElement('ossigeno')).toBe('O');   // it
+    expect(matchElement('zolfo')).toBe('S');      // it
+    expect(matchElement('azoto')).toBe('N');      // it
+    expect(matchElement('hidrogênio')).toBe('H'); // pt
+    expect(matchElement('enxofre')).toBe('S');    // pt
+    expect(matchElement('oxigênio')).toBe('O');   // pt
+  });
+
   it('ignora mayúsculas y palabras alrededor', () => {
     expect(matchElement('dame OXÍGENO por favor')).toBe('O');
     expect(matchElement('quiero un poco de Sodio')).toBe('Na');
@@ -51,12 +61,36 @@ describe('matchElement', () => {
 });
 
 describe('matchCommand', () => {
-  it('reconoce la orden de mezclar (español e inglés)', () => {
-    expect(matchCommand('mezclar')).toBe('mix');
-    expect(matchCommand('dale, mezcla todo')).toBe('mix');
-    expect(matchCommand('combinar')).toBe('mix');
-    expect(matchCommand('mix it')).toBe('mix');
+  it('reconoce mezclar en los 4 idiomas', () => {
+    expect(matchCommand('mezclar')).toBe('mix');     // es
+    expect(matchCommand('mix it')).toBe('mix');      // en
+    expect(matchCommand('mescola tutto')).toBe('mix'); // it
+    expect(matchCommand('misturar')).toBe('mix');    // pt
   });
+
+  it('reconoce vaciar en los 4 idiomas', () => {
+    expect(matchCommand('vaciar')).toBe('clear');    // es
+    expect(matchCommand('empty')).toBe('clear');     // en
+    expect(matchCommand('svuota')).toBe('clear');    // it
+    expect(matchCommand('esvaziar')).toBe('clear');  // pt
+  });
+
+  it('reconoce la orden de depositar genérica', () => {
+    expect(matchCommand('echar')).toBe('deposit');
+    expect(matchCommand('soltar al cuenco')).toBe('deposit');
+    expect(matchCommand('drop')).toBe('deposit');
+    expect(matchCommand('jogar')).toBe('deposit');
+  });
+
+  it('reconoce depositar por mano (izquierda/derecha)', () => {
+    expect(matchCommand('izquierda')).toBe('deposit-left');
+    expect(matchCommand('mano derecha')).toBe('deposit-right');
+    expect(matchCommand('left')).toBe('deposit-left');
+    expect(matchCommand('destra')).toBe('deposit-right');
+    // la dirección gana sobre el depósito genérico
+    expect(matchCommand('echar a la izquierda')).toBe('deposit-left');
+  });
+
   it('devuelve null si no hay orden', () => {
     expect(matchCommand('')).toBeNull();
     expect(matchCommand('hidrogeno')).toBeNull();

--- a/src/voice.ts
+++ b/src/voice.ts
@@ -240,8 +240,11 @@ export class VoiceRecognizer {
       const code = (e as { error?: string })?.error;
       if (code === 'not-allowed' || code === 'service-not-allowed') this.running = false;
     };
-    // El reconocimiento se corta solo tras silencios; lo reanudamos si seguimos activos.
-    rec.onend = () => { if (this.running) { try { rec.start(); } catch { /* ya activo */ } } };
+    // El reconocimiento se corta solo tras silencios; lo reanudamos si seguimos
+    // activos Y este sigue siendo el reconocedor vigente. El check `this.rec === rec`
+    // evita que un reconocedor reemplazado (p.ej. al cambiar de idioma en vivo) se
+    // reanime en su propio onend y queden dos corriendo en paralelo.
+    rec.onend = () => { if (this.running && this.rec === rec) { try { rec.start(); } catch { /* ya activo */ } } };
 
     this.rec = rec;
     this.running = true;

--- a/src/voice.ts
+++ b/src/voice.ts
@@ -14,14 +14,15 @@ function normalize(s: string): string {
 // Palabras (español + inglés) → símbolo. A propósito NO mapeamos letras sueltas
 // ("o", "c", "n"...) porque chocan con palabras comunes y darían falsos positivos.
 const WORD_TO_SYMBOL: Record<string, ElementSymbol> = {
-  hidrogeno: 'H', hydrogen: 'H',
-  oxigeno: 'O', oxygen: 'O',
-  carbono: 'C', carbon: 'C',
-  nitrogeno: 'N', nitrogen: 'N',
+  // español · inglés · italiano · portugués
+  hidrogeno: 'H', hydrogen: 'H', idrogeno: 'H', hidrogenio: 'H',
+  oxigeno: 'O', oxygen: 'O', ossigeno: 'O', oxigenio: 'O',
+  carbono: 'C', carbon: 'C', carbonio: 'C',
+  nitrogeno: 'N', nitrogen: 'N', azoto: 'N', nitrogenio: 'N',
   sodio: 'Na', sodium: 'Na',
   cloro: 'Cl', chlorine: 'Cl',
-  fluor: 'F', fluorine: 'F',
-  azufre: 'S', sulfur: 'S', sulphur: 'S',
+  fluor: 'F', fluorine: 'F', fluoro: 'F',
+  azufre: 'S', sulfur: 'S', sulphur: 'S', zolfo: 'S', enxofre: 'S',
   fosforo: 'P', phosphorus: 'P',
 };
 
@@ -39,13 +40,39 @@ export function matchElement(transcript: string): ElementSymbol | null {
   return found;
 }
 
-// Palabras que disparan la orden de "mezclar" el cuenco (español + inglés).
-const MIX_WORDS = new Set(['mezclar', 'mezcla', 'mezclalo', 'combinar', 'combina', 'mix', 'brew']);
+/** Órdenes por voz: mezclar, vaciar, o depositar (genérico / mano izquierda / derecha). */
+export type VoiceCommand = 'mix' | 'clear' | 'deposit' | 'deposit-left' | 'deposit-right';
 
-/** Detecta la orden de mezclar el cuenco. Devuelve `'mix'` o `null`. */
-export function matchCommand(transcript: string): 'mix' | null {
+// Vocabulario por orden (es · en · it · pt). normalize() ya quitó acentos.
+const MIX_WORDS = new Set([
+  'mezclar', 'mezcla', 'mezclalo', 'combinar', 'combina',
+  'mix', 'brew', 'combine', 'mescola', 'mescolare', 'misturar', 'mistura',
+]);
+const CLEAR_WORDS = new Set([
+  'vaciar', 'vacia', 'vacialo', 'limpiar', 'limpia',
+  'empty', 'clear', 'svuota', 'svuotare', 'pulisci', 'esvaziar', 'esvazia', 'limpar',
+]);
+const DEPOSIT_WORDS = new Set([
+  'echar', 'echa', 'soltar', 'solta', 'tirar', 'tira', 'depositar', 'deposita', 'vaya',
+  'drop', 'metti', 'mettere', 'butta', 'lascia', 'jogar', 'joga',
+]);
+const LEFT_WORDS = new Set(['izquierda', 'left', 'sinistra', 'esquerda']);
+const RIGHT_WORDS = new Set(['derecha', 'right', 'destra', 'direita']);
+
+/**
+ * Detecta una orden de voz. Precedencia: dirección (izquierda/derecha) sobre el
+ * depósito genérico, y depósito/mezclar/vaciar entre sí. Devuelve `null` si no
+ * se nombró ninguna orden.
+ */
+export function matchCommand(transcript: string): VoiceCommand | null {
   const words = normalize(transcript).split(/[^a-z]+/).filter(Boolean);
-  return words.some((w) => MIX_WORDS.has(w)) ? 'mix' : null;
+  const has = (set: Set<string>) => words.some((w) => set.has(w));
+  if (has(LEFT_WORDS)) return 'deposit-left';
+  if (has(RIGHT_WORDS)) return 'deposit-right';
+  if (has(DEPOSIT_WORDS)) return 'deposit';
+  if (has(MIX_WORDS)) return 'mix';
+  if (has(CLEAR_WORDS)) return 'clear';
+  return null;
 }
 
 /** Un producto invocable por voz: su id (fórmula) y los nombres que lo nombran (ES/EN). */
@@ -97,6 +124,8 @@ export function resolveLang(raw: string | null | undefined): string {
   }
   if (base === 'es') return 'es-ES';
   if (base === 'en') return 'en-US';
+  if (base === 'it') return 'it-IT';
+  if (base === 'pt') return 'pt-BR';
   return 'en-US';
 }
 
@@ -137,8 +166,8 @@ function getCtor(): SpeechRecognitionCtor | null {
 export interface VoiceHandlers {
   /** Nombró un átomo. */
   onElement?: (s: ElementSymbol) => void;
-  /** Pidió mezclar el cuenco. */
-  onCommand?: (c: 'mix') => void;
+  /** Dio una orden (mezclar, vaciar, depositar…). */
+  onCommand?: (c: VoiceCommand) => void;
   /** Invocó un producto ya descubierto (devuelve su fórmula/id). */
   onProduct?: (id: string) => void;
   /** Productos invocables ahora mismo (cambia a medida que se descubren). */
@@ -179,9 +208,10 @@ export class VoiceRecognizer {
       // Resolvemos el intent con precedencia y armamos una clave para el anti-rebote.
       let key: string | null = null;
       let fire: (() => void) | null = null;
-      if (matchCommand(transcript)) {
-        key = 'cmd:mix';
-        fire = () => handlers.onCommand?.('mix');
+      const command = matchCommand(transcript);
+      if (command) {
+        key = `cmd:${command}`;
+        fire = () => handlers.onCommand?.(command);
       } else {
         const pid = handlers.getProducts ? matchProduct(transcript, handlers.getProducts()) : null;
         if (pid) {


### PR DESCRIPTION
## Qué cambia

Tres cosas pedidas, sobre la dinámica del cuenco de alquimia:

### 1. Multi-idioma (ES · EN · IT · PT)
- Toda la UI (overlay, HUD del cuenco, paleta, botones, estante, info-card, toasts) y los nombres de elementos/moléculas se traducen a los 4 idiomas.
- **Default inglés.** Selector **siempre visible**: grilla 2×2 con **banderas (SVG, se ven en todos los SO)** + nombre nativo en el overlay, y una **barra persistente** arriba a la derecha durante el juego.
- Cambiar idioma en vivo reinicia el reconocimiento de voz en el nuevo locale.
- Nuevo módulo `src/i18n.ts` (puro, testeado).

### 2. Comandos de voz nuevos
- **"vaciar"** vacía el cuenco; **"mezclar"** sigue cocinando.
- **"echar" / "izquierda" / "derecha"** depositan en el cuenco lo que sostiene la mano (genérico o por mano), sin tener que acercarla físicamente.
- Vocabulario de comandos y de elementos en los 4 idiomas; `matchCommand` pasa a un union tipado.

### 3. Un solo permiso
- Cámara y micrófono se piden en **un único prompt** (`getUserMedia` con `audio`), con fallback a solo-cámara si no hay micrófono. Antes eran dos permisos encadenados (cámara, y después el de la voz).

## Arquitectura
- Dominio sin DOM: `chemistry.ts` gana nombres en 4 idiomas + helpers `localizedName`/`allNames`; `i18n.ts` es puro. Toda la lógica nueva tiene tests.
- De paso: `isElement` usa `hasOwnProperty` (robustez), corrige un hallazgo de la review anterior.

## Verificación
- `npm test` → **74 tests** verde (chemistry, i18n, inventory, voice, hands).
- `npm run build` limpio.
- Runtime (cámara sintética): selector con banderas SVG en 2×2, default inglés, switch a IT/PT cambia título + overlay + barra; escena del cuenco traducida.

> Nota: las banderas son SVG inline (no emoji) para que se vean también en Windows. Este branch sale de master ya con el PR #2 mergeado e incluye además la traducción del README a inglés.
