### PR TITLE
feat: descripciones i18n (4 idiomas) + selector de idioma separado

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,9 +18,14 @@
     <div id="langbar" class="langbar" role="group" aria-label="Language / Idioma"></div>
 
     <div id="overlay">
-      <div class="card">
+      <!-- Caja 1: selector de idioma, separado de la cámara -->
+      <div class="card lang-card">
         <div class="lang-title">🌐 Language · Idioma</div>
         <div id="langs" class="langs" role="group" aria-label="Language / Idioma"></div>
+      </div>
+
+      <!-- Caja 2: marca + permiso de cámara -->
+      <div class="card">
         <div class="logo">⚗️</div>
         <h1 id="title">Alchemy&nbsp;Cauldron</h1>
         <p class="lead">Enable your camera to play.</p>

--- a/src/chemistry.test.ts
+++ b/src/chemistry.test.ts
@@ -200,9 +200,11 @@ describe('catálogo', () => {
       expect(el.atomicNumber).toBe(totalElectrons);
     }
   });
-  it('toda molécula tiene una descripción no vacía', () => {
+  it('toda molécula tiene descripción no vacía en los 4 idiomas', () => {
     for (const m of MOLECULES) {
-      expect(m.description.trim().length).toBeGreaterThan(10);
+      for (const d of [m.description, m.descriptionEs, m.descriptionIt, m.descriptionPt]) {
+        expect(d.trim().length).toBeGreaterThan(10);
+      }
     }
   });
 

--- a/src/chemistry.ts
+++ b/src/chemistry.ts
@@ -54,8 +54,14 @@ export interface Molecule {
   /** Nombre en portugués. */
   namePt: string;
   color: string;
-  /** Descripción breve: para qué se usa / por qué importa (en inglés). */
+  /** Descripción breve (inglés): para qué se usa / por qué importa. */
   description: string;
+  /** Descripción en español. */
+  descriptionEs: string;
+  /** Descripción en italiano. */
+  descriptionIt: string;
+  /** Descripción en portugués. */
+  descriptionPt: string;
   /** Cuántos átomos de cada elemento la forman. */
   composition: Composition;
   /**
@@ -99,6 +105,9 @@ export const MOLECULES: Molecule[] = [
   {
     formula: 'H₂O', name: 'Water', nameEs: 'Agua', nameIt: 'Acqua', namePt: 'Água', color: '#38bdf8',
     description: 'The basis of all known life. Covers about 71% of Earth and makes up most of your body.',
+    descriptionEs: 'La base de toda forma de vida conocida. Cubre cerca del 71% de la Tierra y forma la mayor parte de tu cuerpo.',
+    descriptionIt: 'La base di ogni forma di vita conosciuta. Copre circa il 71% della Terra e costituisce gran parte del tuo corpo.',
+    descriptionPt: 'A base de toda forma de vida conhecida. Cobre cerca de 71% da Terra e forma a maior parte do seu corpo.',
     composition: { H: 2, O: 1 },
     atoms: [
       { symbol: 'O', x: 0, y: -0.15 },
@@ -110,6 +119,9 @@ export const MOLECULES: Molecule[] = [
   {
     formula: 'CO₂', name: 'Carbon dioxide', nameEs: 'Dióxido de carbono', nameIt: 'Anidride carbonica', namePt: 'Dióxido de carbono', color: '#94a3b8',
     description: 'Exhaled by animals, used by plants in photosynthesis, and a key greenhouse gas.',
+    descriptionEs: 'La exhalan los animales, la usan las plantas en la fotosíntesis, y es un gas de efecto invernadero clave.',
+    descriptionIt: 'Espirata dagli animali, usata dalle piante nella fotosintesi, è un gas serra fondamentale.',
+    descriptionPt: 'Exalado pelos animais, usado pelas plantas na fotossíntese e um gás de efeito estufa importante.',
     composition: { C: 1, O: 2 },
     atoms: [
       { symbol: 'C', x: 0, y: 0 },
@@ -121,6 +133,9 @@ export const MOLECULES: Molecule[] = [
   {
     formula: 'NH₃', name: 'Ammonia', nameEs: 'Amoníaco', nameIt: 'Ammoniaca', namePt: 'Amônia', color: '#a5b4fc',
     description: 'Used to make fertilizers that feed most of the world, and in cleaning products.',
+    descriptionEs: 'Se usa para fabricar fertilizantes que alimentan a buena parte del mundo, y en productos de limpieza.',
+    descriptionIt: 'Usata per produrre fertilizzanti che nutrono gran parte del mondo, e nei prodotti per la pulizia.',
+    descriptionPt: 'Usada para fabricar fertilizantes que alimentam boa parte do mundo, e em produtos de limpeza.',
     composition: { N: 1, H: 3 },
     atoms: [
       { symbol: 'N', x: 0, y: 0 },
@@ -133,6 +148,9 @@ export const MOLECULES: Molecule[] = [
   {
     formula: 'CH₄', name: 'Methane', nameEs: 'Metano', nameIt: 'Metano', namePt: 'Metano', color: '#5eead4',
     description: 'The main component of natural gas — a common fuel and a potent greenhouse gas.',
+    descriptionEs: 'El componente principal del gas natural: un combustible común y un potente gas de efecto invernadero.',
+    descriptionIt: 'Il componente principale del gas naturale: un combustibile comune e un potente gas serra.',
+    descriptionPt: 'O principal componente do gás natural: um combustível comum e um potente gás de efeito estufa.',
     composition: { C: 1, H: 4 },
     atoms: [
       { symbol: 'C', x: 0, y: 0 },
@@ -149,6 +167,9 @@ export const MOLECULES: Molecule[] = [
   {
     formula: 'NaCl', name: 'Salt (sodium chloride)', nameEs: 'Sal', nameIt: 'Sale', namePt: 'Sal', color: '#fcd34d',
     description: 'Everyday table salt. Essential for life and used to season and preserve food.',
+    descriptionEs: 'La sal de mesa de todos los días. Esencial para la vida y usada para condimentar y conservar alimentos.',
+    descriptionIt: 'Il comune sale da cucina. Essenziale per la vita e usato per insaporire e conservare i cibi.',
+    descriptionPt: 'O sal de cozinha do dia a dia. Essencial à vida e usado para temperar e conservar alimentos.',
     composition: { Na: 1, Cl: 1 },
     atoms: [
       { symbol: 'Na', x: -0.75, y: 0 },
@@ -159,6 +180,9 @@ export const MOLECULES: Molecule[] = [
   {
     formula: 'HCl', name: 'Hydrochloric acid', nameEs: 'Ácido clorhídrico', nameIt: 'Acido cloridrico', namePt: 'Ácido clorídrico', color: '#86efac',
     description: 'Your stomach makes it to digest food. Also a workhorse acid in industry.',
+    descriptionEs: 'Tu estómago lo produce para digerir la comida. También es un ácido clave en la industria.',
+    descriptionIt: 'Il tuo stomaco lo produce per digerire il cibo. È anche un acido fondamentale nell\'industria.',
+    descriptionPt: 'Seu estômago o produz para digerir a comida. Também é um ácido essencial na indústria.',
     composition: { H: 1, Cl: 1 },
     atoms: [
       { symbol: 'H', x: -0.65, y: 0 },
@@ -169,6 +193,9 @@ export const MOLECULES: Molecule[] = [
   {
     formula: 'H₂', name: 'Hydrogen gas', nameEs: 'Hidrógeno gaseoso', nameIt: 'Idrogeno gassoso', namePt: 'Hidrogênio gasoso', color: '#7dd3fc',
     description: 'The lightest gas and a clean fuel: burning it produces only water.',
+    descriptionEs: 'El gas más liviano y un combustible limpio: al quemarse solo produce agua.',
+    descriptionIt: 'Il gas più leggero e un combustibile pulito: bruciando produce solo acqua.',
+    descriptionPt: 'O gás mais leve e um combustível limpo: ao queimar produz apenas água.',
     composition: { H: 2 },
     atoms: [
       { symbol: 'H', x: -0.6, y: 0 },
@@ -179,6 +206,9 @@ export const MOLECULES: Molecule[] = [
   {
     formula: 'O₂', name: 'Oxygen gas', nameEs: 'Oxígeno gaseoso', nameIt: 'Ossigeno gassoso', namePt: 'Oxigênio gasoso', color: '#f87171',
     description: 'The gas you breathe to stay alive — about 21% of the air around you.',
+    descriptionEs: 'El gas que respirás para seguir vivo: cerca del 21% del aire que te rodea.',
+    descriptionIt: 'Il gas che respiri per restare in vita: circa il 21% dell\'aria intorno a te.',
+    descriptionPt: 'O gás que você respira para se manter vivo: cerca de 21% do ar ao seu redor.',
     composition: { O: 2 },
     atoms: [
       { symbol: 'O', x: -0.62, y: 0 },
@@ -189,6 +219,9 @@ export const MOLECULES: Molecule[] = [
   {
     formula: 'N₂', name: 'Nitrogen gas', nameEs: 'Nitrógeno gaseoso', nameIt: 'Azoto gassoso', namePt: 'Nitrogênio gasoso', color: '#818cf8',
     description: 'About 78% of the air. Inert and often used to keep food fresh.',
+    descriptionEs: 'Cerca del 78% del aire. Inerte y muy usado para mantener frescos los alimentos.',
+    descriptionIt: 'Circa il 78% dell\'aria. Inerte e spesso usato per mantenere freschi gli alimenti.',
+    descriptionPt: 'Cerca de 78% do ar. Inerte e muito usado para manter os alimentos frescos.',
     composition: { N: 2 },
     atoms: [
       { symbol: 'N', x: -0.6, y: 0 },
@@ -199,6 +232,9 @@ export const MOLECULES: Molecule[] = [
   {
     formula: 'H₂O₂', name: 'Hydrogen peroxide', nameEs: 'Peróxido de hidrógeno', nameIt: 'Perossido di idrogeno', namePt: 'Peróxido de hidrogênio', color: '#bae6fd',
     description: 'A pale blue liquid used to disinfect wounds and bleach hair — water with one extra oxygen.',
+    descriptionEs: 'Un líquido azul pálido que se usa para desinfectar heridas y decolorar el pelo: agua con un oxígeno de más.',
+    descriptionIt: 'Un liquido azzurro pallido usato per disinfettare ferite e schiarire i capelli: acqua con un ossigeno in più.',
+    descriptionPt: 'Um líquido azul-claro usado para desinfetar feridas e clarear o cabelo: água com um oxigênio a mais.',
     composition: { H: 2, O: 2 },
     atoms: [
       { symbol: 'O', x: -0.5, y: 0 },
@@ -211,6 +247,9 @@ export const MOLECULES: Molecule[] = [
   {
     formula: 'O₃', name: 'Ozone', nameEs: 'Ozono', nameIt: 'Ozono', namePt: 'Ozônio', color: '#fca5a5',
     description: 'High in the atmosphere it shields us from UV rays; at ground level it is a pollutant.',
+    descriptionEs: 'En lo alto de la atmósfera nos protege de los rayos UV; a nivel del suelo es un contaminante.',
+    descriptionIt: 'In alto nell\'atmosfera ci protegge dai raggi UV; al livello del suolo è un inquinante.',
+    descriptionPt: 'No alto da atmosfera nos protege dos raios UV; ao nível do solo é um poluente.',
     composition: { O: 3 },
     atoms: [
       { symbol: 'O', x: 0, y: -0.25 },
@@ -222,6 +261,9 @@ export const MOLECULES: Molecule[] = [
   {
     formula: 'CO', name: 'Carbon monoxide', nameEs: 'Monóxido de carbono', nameIt: 'Monossido di carbonio', namePt: 'Monóxido de carbono', color: '#cbd5e1',
     description: 'A colorless, odorless and toxic gas from incomplete burning of fuels.',
+    descriptionEs: 'Un gas incoloro, inodoro y tóxico que sale de la combustión incompleta de los combustibles.',
+    descriptionIt: 'Un gas incolore, inodore e tossico prodotto dalla combustione incompleta dei combustibili.',
+    descriptionPt: 'Um gás incolor, inodoro e tóxico vindo da queima incompleta de combustíveis.',
     composition: { C: 1, O: 1 },
     atoms: [
       { symbol: 'C', x: -0.6, y: 0 },
@@ -232,6 +274,9 @@ export const MOLECULES: Molecule[] = [
   {
     formula: 'NO', name: 'Nitric oxide', nameEs: 'Óxido nítrico', nameIt: 'Ossido nitrico', namePt: 'Óxido nítrico', color: '#c7d2fe',
     description: 'A signaling molecule in your body that relaxes blood vessels and controls blood flow.',
+    descriptionEs: 'Una molécula señal de tu cuerpo que relaja los vasos sanguíneos y regula el flujo de sangre.',
+    descriptionIt: 'Una molecola segnale del tuo corpo che rilassa i vasi sanguigni e regola il flusso del sangue.',
+    descriptionPt: 'Uma molécula sinalizadora do seu corpo que relaxa os vasos sanguíneos e regula o fluxo de sangue.',
     composition: { N: 1, O: 1 },
     atoms: [
       { symbol: 'N', x: -0.6, y: 0 },
@@ -242,6 +287,9 @@ export const MOLECULES: Molecule[] = [
   {
     formula: 'SO₂', name: 'Sulfur dioxide', nameEs: 'Dióxido de azufre', nameIt: 'Anidride solforosa', namePt: 'Dióxido de enxofre', color: '#fde047',
     description: 'A sharp-smelling gas from volcanoes and burning coal; used to preserve dried fruit.',
+    descriptionEs: 'Un gas de olor penetrante de los volcanes y la quema de carbón; se usa para conservar fruta seca.',
+    descriptionIt: 'Un gas dall\'odore pungente dei vulcani e della combustione del carbone; usato per conservare la frutta secca.',
+    descriptionPt: 'Um gás de cheiro forte dos vulcões e da queima de carvão; usado para conservar frutas secas.',
     composition: { S: 1, O: 2 },
     atoms: [
       { symbol: 'S', x: 0, y: -0.1 },
@@ -253,6 +301,9 @@ export const MOLECULES: Molecule[] = [
   {
     formula: 'H₂S', name: 'Hydrogen sulfide', nameEs: 'Sulfuro de hidrógeno', nameIt: 'Solfuro di idrogeno', namePt: 'Sulfeto de hidrogênio', color: '#fef08a',
     description: 'The "rotten egg" gas, toxic in high amounts and produced by decaying matter.',
+    descriptionEs: 'El gas con olor a "huevo podrido", tóxico en grandes cantidades y producido por la materia en descomposición.',
+    descriptionIt: 'Il gas dall\'odore di "uova marce", tossico in grandi quantità e prodotto dalla materia in decomposizione.',
+    descriptionPt: 'O gás com cheiro de "ovo podre", tóxico em grandes quantidades e produzido pela matéria em decomposição.',
     composition: { H: 2, S: 1 },
     atoms: [
       { symbol: 'S', x: 0, y: -0.15 },
@@ -264,6 +315,9 @@ export const MOLECULES: Molecule[] = [
   {
     formula: 'HF', name: 'Hydrogen fluoride', nameEs: 'Fluoruro de hidrógeno', nameIt: 'Fluoruro di idrogeno', namePt: 'Fluoreto de hidrogênio', color: '#bef264',
     description: 'Dissolved in water it becomes hydrofluoric acid, used to etch glass and silicon.',
+    descriptionEs: 'Disuelto en agua se vuelve ácido fluorhídrico, usado para grabar vidrio y silicio.',
+    descriptionIt: 'Disciolto in acqua diventa acido fluoridrico, usato per incidere vetro e silicio.',
+    descriptionPt: 'Dissolvido em água vira ácido fluorídrico, usado para gravar vidro e silício.',
     composition: { H: 1, F: 1 },
     atoms: [
       { symbol: 'H', x: -0.6, y: 0 },
@@ -274,6 +328,9 @@ export const MOLECULES: Molecule[] = [
   {
     formula: 'PH₃', name: 'Phosphine', nameEs: 'Fosfina', nameIt: 'Fosfina', namePt: 'Fosfina', color: '#fdba74',
     description: 'A toxic, flammable gas with a garlic-like smell, used in the semiconductor industry.',
+    descriptionEs: 'Un gas tóxico e inflamable con olor a ajo, usado en la industria de los semiconductores.',
+    descriptionIt: 'Un gas tossico e infiammabile con odore di aglio, usato nell\'industria dei semiconduttori.',
+    descriptionPt: 'Um gás tóxico e inflamável com cheiro de alho, usado na indústria de semicondutores.',
     composition: { P: 1, H: 3 },
     atoms: [
       { symbol: 'P', x: 0, y: 0 },
@@ -289,6 +346,9 @@ export const MOLECULES: Molecule[] = [
   {
     formula: 'H₂CO₃', name: 'Carbonic acid', nameEs: 'Ácido carbónico', nameIt: 'Acido carbonico', namePt: 'Ácido carbônico', color: '#67e8f9',
     description: 'Forms when CO₂ dissolves in water — it is what makes soda fizzy and rain slightly acidic.',
+    descriptionEs: 'Se forma cuando el CO₂ se disuelve en agua: es lo que hace burbujeante a la gaseosa y levemente ácida a la lluvia.',
+    descriptionIt: 'Si forma quando la CO₂ si scioglie in acqua: è ciò che rende frizzante la bibita e leggermente acida la pioggia.',
+    descriptionPt: 'Forma-se quando o CO₂ se dissolve na água: é o que deixa o refrigerante borbulhante e a chuva levemente ácida.',
     composition: { H: 2, C: 1, O: 3 }, compound: true,
     atoms: [
       { symbol: 'C', x: 0, y: 0 },
@@ -306,6 +366,9 @@ export const MOLECULES: Molecule[] = [
   {
     formula: 'NH₄Cl', name: 'Ammonium chloride', nameEs: 'Cloruro de amonio', nameIt: 'Cloruro di ammonio', namePt: 'Cloreto de amônio', color: '#c4b5fd',
     description: 'A salt of ammonia and hydrochloric acid, used in fertilizers, batteries and cough medicine.',
+    descriptionEs: 'Una sal de amoníaco y ácido clorhídrico, usada en fertilizantes, pilas y jarabes para la tos.',
+    descriptionIt: 'Un sale di ammoniaca e acido cloridrico, usato in fertilizzanti, batterie e sciroppi per la tosse.',
+    descriptionPt: 'Um sal de amônia e ácido clorídrico, usado em fertilizantes, pilhas e xaropes para tosse.',
     composition: { N: 1, H: 4, Cl: 1 }, compound: true,
     atoms: [
       { symbol: 'N', x: -0.6, y: 0 },
@@ -323,6 +386,9 @@ export const MOLECULES: Molecule[] = [
   {
     formula: 'H₂SO₃', name: 'Sulfurous acid', nameEs: 'Ácido sulfuroso', nameIt: 'Acido solforoso', namePt: 'Ácido sulfuroso', color: '#fef9c3',
     description: 'Forms when sulfur dioxide dissolves in water; the chemistry behind acid rain.',
+    descriptionEs: 'Se forma cuando el dióxido de azufre se disuelve en agua; es la química detrás de la lluvia ácida.',
+    descriptionIt: 'Si forma quando l\'anidride solforosa si scioglie in acqua; è la chimica dietro la pioggia acida.',
+    descriptionPt: 'Forma-se quando o dióxido de enxofre se dissolve na água; é a química por trás da chuva ácida.',
     composition: { H: 2, S: 1, O: 3 }, compound: true,
     atoms: [
       { symbol: 'S', x: 0, y: 0 },
@@ -340,6 +406,9 @@ export const MOLECULES: Molecule[] = [
   {
     formula: 'NH₄OH', name: 'Ammonium hydroxide', nameEs: 'Hidróxido de amonio', nameIt: 'Idrossido di ammonio', namePt: 'Hidróxido de amônio', color: '#ddd6fe',
     description: 'Ammonia dissolved in water — the cloudy "ammonia" sold as a household cleaner.',
+    descriptionEs: 'Amoníaco disuelto en agua: el "amoníaco" turbio que se vende como limpiador doméstico.',
+    descriptionIt: 'Ammoniaca disciolta in acqua: l\'"ammoniaca" torbida venduta come detergente per la casa.',
+    descriptionPt: 'Amônia dissolvida em água: a "amônia" turva vendida como produto de limpeza doméstica.',
     composition: { N: 1, H: 5, O: 1 }, compound: true,
     atoms: [
       { symbol: 'N', x: -0.7, y: 0 },
@@ -486,6 +555,16 @@ export function localizedName(e: Named, lang: Lang): string {
 /** Los 4 nombres de un elemento o molécula (para el match de voz multi-idioma). */
 export function allNames(e: Named): string[] {
   return [e.name, e.nameEs, e.nameIt, e.namePt];
+}
+
+/** Descripción de una molécula en el idioma dado (inglés por defecto). */
+export function localizedDescription(m: Molecule, lang: Lang): string {
+  switch (lang) {
+    case 'es': return m.descriptionEs;
+    case 'it': return m.descriptionIt;
+    case 'pt': return m.descriptionPt;
+    default: return m.description;
+  }
 }
 
 /** Etiqueta legible de un ingrediente en el idioma dado. */

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,19 +56,36 @@ const startBtn = document.querySelector<HTMLButtonElement>('#start')!;
 // pantallas HiDPI sin reventar el fill-rate en pantallas 3x.
 const DPR = Math.min(window.devicePixelRatio || 1, 2);
 
-// Cache del layout de la paleta. Declarado ACÁ —antes de resize()— a propósito:
-// resize() corre en la evaluación del módulo y lo invalida, así que si la
-// declaración `let` quedara más abajo caería en la temporal dead zone y tiraría
-// "Cannot access 'tilesCache' before initialization", abortando todo main.ts.
+// Caches de layout/geometría que solo dependen del tamaño del canvas. Declarados
+// ACÁ —antes de resize()— a propósito: resize() corre en la evaluación del módulo
+// y los invalida, así que si las declaraciones `let` quedaran más abajo caerían en
+// la temporal dead zone ("Cannot access ... before initialization"), abortando
+// todo main.ts. Se nulean en resize() y se recalculan perezosamente (mismo patrón
+// que el resto de caches por-evento de este archivo).
 interface Tile { symbol: ElementSymbol; x: number; y: number; size: number; }
+interface Rect { x: number; y: number; w: number; h: number; }
+interface CauldronGeo { cx: number; cy: number; r: number; }
+interface ShelfCell extends Rect { formula: string; }
+
 let tilesCache: Tile[] | null = null;
+let cauldronGeoCache: CauldronGeo | null = null;
+let mixRectCache: Rect | null = null;
+let clearRectCache: Rect | null = null;
+let liquidGradientCache: CanvasGradient | null = null;
+let shelfCellsCache: ShelfCell[] | null = null;
 
 function resize() {
   canvas.width = window.innerWidth * DPR;
   canvas.height = window.innerHeight * DPR;
   canvas.style.width = `${window.innerWidth}px`;
   canvas.style.height = `${window.innerHeight}px`;
-  tilesCache = null; // el layout de la paleta depende del ancho
+  // Todo lo que depende del tamaño del canvas se invalida de una.
+  tilesCache = null;
+  cauldronGeoCache = null;
+  mixRectCache = null;
+  clearRectCache = null;
+  liquidGradientCache = null;
+  shelfCellsCache = null;
 }
 window.addEventListener('resize', resize);
 resize();
@@ -165,10 +182,27 @@ const makeHand = (): HandState => ({
   shelfId: null, shelfMs: 0,
 });
 type SlotName = 'Left' | 'Right';
+// Constante reusada en el hot path: evita crear un array nuevo por frame en cada
+// loop sobre las dos manos (syncHands, updateInteraction, render, draws).
+const SLOTS: readonly SlotName[] = ['Left', 'Right'];
 const hands: Record<SlotName, HandState> = { Left: makeHand(), Right: makeHand() };
 
 // El cuenco de alquimia: multiset de ingredientes acumulados (átomos y/o productos).
 const contents: Cauldron = {};
+// Cache de los ids con cantidad > 0. `contents` solo cambia en deposit/clear, así
+// que en vez de recorrer Object.keys(...).filter(...) ~3×/frame lo derivamos una
+// vez por cambio. Se invalida con invalidateCauldron().
+let cauldronIdsCache: string[] | null = null;
+function invalidateCauldron() { cauldronIdsCache = null; }
+function cauldronIds(): string[] {
+  return (cauldronIdsCache ??= Object.keys(contents).filter((k) => (contents[k] ?? 0) > 0));
+}
+
+// Snapshot del inventario (inventory.list() copia el array interno). Solo cambia
+// en un `mezclar` exitoso (inventory.add); lo cacheamos para no copiar por frame.
+let invListCache: string[] | null = null;
+function invList(): string[] { return (invListCache ??= inventory.list()); }
+function invalidateInventory() { invListCache = null; shelfCellsCache = null; }
 
 // Moléculas levitando tras una mezcla exitosa. Posiciones en fracciones del canvas.
 interface Floating { molecule: Molecule; x: number; y: number; vx: number; vy: number; rot: number; rotVel: number; }
@@ -287,6 +321,7 @@ function resetGame() {
   floating.length = 0;
   toasts.length = 0;
   for (const k of Object.keys(contents)) delete contents[k];
+  invalidateCauldron();
   cooldown = 0;
 }
 
@@ -371,7 +406,7 @@ function syncHands(detected: Hand[]) {
     st.x = (1 - tip.x) * canvas.width;
     st.y = tip.y * canvas.height;
   }
-  for (const name of ['Left', 'Right'] as SlotName[]) {
+  for (const name of SLOTS) {
     if (!hands[name].present) resetDwell(hands[name]);
   }
 }
@@ -399,42 +434,47 @@ function tileUnder(px: number, py: number, tiles: Tile[]): Tile | null {
   return tiles.find((t) => px >= t.x && px <= t.x + t.size && py >= t.y && py <= t.y + t.size) ?? null;
 }
 
-/** Cuenco central (círculo). */
-function cauldronGeo() {
+/** Cuenco central (círculo). Cacheado por tamaño de canvas (se nulea en resize). */
+function cauldronGeo(): CauldronGeo {
+  if (cauldronGeoCache) return cauldronGeoCache;
   const cx = canvas.width / 2;
   const cy = canvas.height * 0.5;
   const r = Math.min(canvas.width * 0.17, canvas.height * 0.26, 230 * DPR);
-  return { cx, cy, r };
+  return (cauldronGeoCache = { cx, cy, r });
 }
 
-interface Rect { x: number; y: number; w: number; h: number; }
 function mixButtonRect(): Rect {
+  if (mixRectCache) return mixRectCache;
   const c = cauldronGeo();
   const w = Math.min(canvas.width * 0.22, 220 * DPR);
   const h = 64 * DPR;
   const gap = 14 * DPR;
-  return { x: c.cx - w - gap / 2, y: c.cy + c.r + 30 * DPR, w, h };
+  return (mixRectCache = { x: c.cx - w - gap / 2, y: c.cy + c.r + 30 * DPR, w, h });
 }
 function clearButtonRect(): Rect {
+  if (clearRectCache) return clearRectCache;
   const c = cauldronGeo();
   const w = Math.min(canvas.width * 0.15, 150 * DPR);
   const h = 64 * DPR;
   const gap = 14 * DPR;
-  return { x: c.cx + gap / 2, y: c.cy + c.r + 30 * DPR, w, h };
+  return (clearRectCache = { x: c.cx + gap / 2, y: c.cy + c.r + 30 * DPR, w, h });
 }
 function inRect(px: number, py: number, r: Rect): boolean {
   return px >= r.x && px <= r.x + r.w && py >= r.y && py <= r.y + r.h;
 }
 
-/** Celdas del estante de inventario (los últimos SHELF_MAX productos descubiertos). */
-interface ShelfCell extends Rect { formula: string; }
+/**
+ * Celdas del estante de inventario (los últimos SHELF_MAX productos descubiertos).
+ * Cacheado: solo cambia al descubrir un producto (invalidateInventory) o en resize.
+ */
 function shelfCells(): ShelfCell[] {
-  const list = inventory.list().slice(-SHELF_MAX);
+  if (shelfCellsCache) return shelfCellsCache;
+  const list = invList().slice(-SHELF_MAX);
   const cell = 64 * DPR;
   const gap = 10 * DPR;
   const pad = 16 * DPR;
   const y = canvas.height - cell - 22 * DPR;
-  return list.map((formula, i) => ({ formula, x: pad + i * (cell + gap), y, w: cell, h: cell }));
+  return (shelfCellsCache = list.map((formula, i) => ({ formula, x: pad + i * (cell + gap), y, w: cell, h: cell })));
 }
 
 // ---------------------------------------------------------------------------
@@ -447,7 +487,7 @@ function updateInteraction(dtMs: number) {
   const clr = clearButtonRect();
   const shelf = shelfCells();
 
-  for (const name of ['Left', 'Right'] as SlotName[]) {
+  for (const name of SLOTS) {
     const st = hands[name];
     if (!st.present) { resetDwell(st); continue; }
 
@@ -518,6 +558,7 @@ function deposit(st: HandState) {
   if (!st.held || st.count <= 0) return;
   const c = cauldronGeo();
   contents[st.held] = (contents[st.held] ?? 0) + st.count;
+  invalidateCauldron(); // `contents` cambió → recalcular ids cacheados
   const color = isElement(st.held) ? ELEMENTS[st.held].color : findMolecule(st.held)?.color ?? '#a78bfa';
   particles.burst(c.cx, c.cy, color, 30, 280 * DPR);
   playChime(true);
@@ -526,7 +567,7 @@ function deposit(st: HandState) {
 
 /** ¿El cuenco tiene al menos un ingrediente? */
 function cauldronHasContents(): boolean {
-  return Object.keys(contents).some((k) => (contents[k] ?? 0) > 0);
+  return cauldronIds().length > 0;
 }
 
 /**
@@ -555,6 +596,7 @@ function mezclar() {
   playChime(true);
   spawnFloating(product, c.cx / canvas.width, (c.cy - c.r * 0.8) / canvas.height);
   const isNew = inventory.add(product.formula);
+  if (isNew) invalidateInventory(); // el estante/lexicon cacheados cambiaron
   pushToast(`${localizedName(product, lang)}${isNew ? ' ✦' : ''}`, product.color, c.cx, c.cy - c.r * 0.6);
   clearContents();
   showInfo(product, isNew);
@@ -598,6 +640,7 @@ function depositByVoice(which: SlotName | 'any') {
 
 function clearContents() {
   for (const k of Object.keys(contents)) delete contents[k];
+  invalidateCauldron();
 }
 
 function pushToast(text: string, color: string, px: number, py: number) {
@@ -644,7 +687,7 @@ function ingredientFeedback(st: HandState, color: string, label: string) {
 /** Productos invocables por voz ahora: solo los ya descubiertos (nombres en 4 idiomas). */
 function productLexicon(): ProductLexEntry[] {
   const out: ProductLexEntry[] = [];
-  for (const formula of inventory.list()) {
+  for (const formula of invList()) {
     const m = findMolecule(formula);
     if (m) out.push({ id: formula, names: allNames(m) });
   }
@@ -738,7 +781,7 @@ function render(time: number) {
   drawClearButton();
   drawShelf(time);
   drawVoiceHint();
-  for (const name of ['Left', 'Right'] as SlotName[]) drawHand(hands[name], time);
+  for (const name of SLOTS) drawHand(hands[name], time);
   particles.draw(ctx);
   drawToasts();
 }
@@ -767,7 +810,7 @@ function ingredientColor(id: IngredientId): string {
 
 function drawCauldron(time: number) {
   const { cx, cy, r } = cauldronGeo();
-  const ids = Object.keys(contents).filter((k) => (contents[k] ?? 0) > 0);
+  const ids = cauldronIds();
   const filled = ids.length > 0;
 
   // Halo exterior pulsante.
@@ -780,13 +823,17 @@ function drawCauldron(time: number) {
   ctx.arc(cx, cy, r * 1.5 * pulse, 0, Math.PI * 2);
   ctx.fill();
 
-  // "Líquido" del cuenco.
-  const liquid = ctx.createRadialGradient(cx, cy - r * 0.2, r * 0.1, cx, cy, r);
-  liquid.addColorStop(0, 'rgba(49, 46, 90, 0.92)');
-  liquid.addColorStop(1, 'rgba(12, 14, 30, 0.92)');
+  // "Líquido" del cuenco. El gradiente solo depende de la geometría (cx,cy,r), así
+  // que lo construimos una vez y lo reusamos hasta el próximo resize.
+  if (!liquidGradientCache) {
+    const g = ctx.createRadialGradient(cx, cy - r * 0.2, r * 0.1, cx, cy, r);
+    g.addColorStop(0, 'rgba(49, 46, 90, 0.92)');
+    g.addColorStop(1, 'rgba(12, 14, 30, 0.92)');
+    liquidGradientCache = g;
+  }
   ctx.beginPath();
   ctx.arc(cx, cy, r, 0, Math.PI * 2);
-  ctx.fillStyle = liquid;
+  ctx.fillStyle = liquidGradientCache;
   ctx.fill();
 
   // Borde del cuenco.
@@ -929,7 +976,7 @@ function drawPalette(time: number) {
     ctx.fillText(localizedName(el, lang), t.x + t.size / 2, t.y + t.size * 0.88);
   }
   // Anillo de progreso de dwell sobre el tile en foco.
-  for (const name of ['Left', 'Right'] as SlotName[]) {
+  for (const name of SLOTS) {
     const st = hands[name];
     if (!st.present || !st.dwellSymbol || st.dwellMs <= 0) continue;
     const t = tiles.find((x) => x.symbol === st.dwellSymbol);
@@ -949,7 +996,7 @@ function drawPalette(time: number) {
  * volver a usarlo (en el cuenco o como ingrediente de otra receta).
  */
 function drawShelf(time: number) {
-  const total = inventory.list().length;
+  const total = invList().length;
   const pad = 16 * DPR;
   const cells = shelfCells();
   const labelY = (cells[0]?.y ?? canvas.height - 86 * DPR) - 18 * DPR;
@@ -985,7 +1032,7 @@ function drawShelf(time: number) {
   }
 
   // Anillo de progreso de dwell sobre la celda en foco.
-  for (const name of ['Left', 'Right'] as SlotName[]) {
+  for (const name of SLOTS) {
     const st = hands[name];
     if (!st.present || !st.shelfId || st.shelfMs <= 0) continue;
     const cell = cells.find((c) => c.formula === st.shelfId);

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import {
   isElement,
   ingredientLabel,
   localizedName,
+  localizedDescription,
   allNames,
   ELEMENTS,
   ELEMENT_ORDER,
@@ -697,7 +698,7 @@ function showInfo(m: Molecule, isNew: boolean) {
       <span class="info-formula">${m.formula}</span>
       <span class="info-name">${localizedName(m, lang)}${isNew ? ' ✦' : ''}</span>
     </div>
-    <p class="info-desc">${m.description}</p>
+    <p class="info-desc">${localizedDescription(m, lang)}</p>
     <div class="info-recipe">${recipeText(m.composition)}</div>
     <ul class="info-elements">${elems}</ul>`;
   infoEl.classList.remove('hidden');

--- a/src/style.css
+++ b/src/style.css
@@ -36,8 +36,11 @@ body {
 #overlay {
   position: fixed;
   inset: 0;
-  display: grid;
-  place-items: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
   /* Translúcido: deja ver la "pantalla de juego" animada por detrás. */
   background: rgba(5, 6, 10, 0.55);
   backdrop-filter: blur(3px);
@@ -62,6 +65,11 @@ body {
 }
 
 /* --- Selector de idioma --------------------------------------------------- */
+/* Caja propia, separada de la de la cámara */
+.lang-card {
+  padding: 1.1rem 1.4rem;
+}
+
 .lang-title {
   font-size: 0.72rem;
   font-weight: 600;
@@ -77,7 +85,7 @@ body {
   grid-template-columns: 1fr 1fr;
   gap: 0.5rem;
   max-width: 21rem;
-  margin: 0 auto 1.6rem;
+  margin: 0 auto;
 }
 
 /* Barra persistente arriba a la derecha (también durante el juego) */


### PR DESCRIPTION
Dos mejoras sobre la dinámica del cuenco, pedidas tras probar:

## 1. Descripciones de moléculas en los 4 idiomas
Era lo único que quedaba en inglés: el panel de info mostraba `Molecule.description` (EN) en cualquier idioma. Ahora cada molécula tiene `descriptionEs/It/Pt` y el panel usa `localizedDescription(m, lang)`. i18n completo (UI + nombres + descripciones).

## 2. Selector de idioma separado de la cámara
El overlay pasa a **dos rectángulos apilados**: arriba el selector de idioma (título + banderas 2×2), abajo la marca y el botón "Activar cámara", con un gap entre ambos. Antes estaban apretados en una sola tarjeta.

## Verificación
- `npm test` → 74 tests verde (invariante de descripción extendido a los 4 idiomas).
- `npm run build` limpio.
- Runtime: las dos cajas se ven separadas; default inglés intacto.
